### PR TITLE
Adding a missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ bumpversion==0.5.3
 stevedore==1.29.0
 mock==2.0.0
 pytest==3.6.3
+pytest-django==3.3.3


### PR DESCRIPTION
This dependency was missing for the test environment.
It was working on circleci because of how prepared those environments are