### PR TITLE
Adding git sha to the output of eox-info

### DIFF
--- a/eox_core/urls.py
+++ b/eox_core/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import url
 from eox_core import views
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^eox-info$', views.default_view),
+    url(r'^eox-info$', views.info_view),
 ]

--- a/eox_core/views.py
+++ b/eox_core/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""The views for the exc-core plugin project"""
+"""The generic views for the exc-core plugin project"""
+
 from __future__ import unicode_literals
 
 import json
@@ -11,9 +12,9 @@ from django.shortcuts import render
 import eox_core
 
 
-def default_view(request):
+def info_view(request):
     """
-    The HTTP endopoint to get the eox-core API version
+    Basic view to show the working version and the exact git commit of the installed app
     """
     try:
         git_data = unicode(check_output(["git", "rev-parse", "HEAD"]))

--- a/eox_core/views.py
+++ b/eox_core/views.py
@@ -3,8 +3,10 @@
 from __future__ import unicode_literals
 
 import json
+from subprocess import check_output
 
 from django.http import HttpResponse
+from django.shortcuts import render
 
 import eox_core
 
@@ -13,9 +15,15 @@ def default_view(request):
     """
     The HTTP endopoint to get the eox-core API version
     """
+    try:
+        git_data = unicode(check_output(["git", "rev-parse", "HEAD"]))
+    except Exception as e:
+        git_data = ""
+
     response_data = {
         "version": eox_core.__version__,
         "name": "eox-core",
+        "git": git_data.rstrip('\r\n'),
     }
     return HttpResponse(
         json.dumps(response_data),


### PR DESCRIPTION
This PR adds extra information to the info view

The git sha is there to test the integrity of the version number or to provide extra granularity in case the installed version does not match exactly with a release