### PR TITLE
Allow invitation-only enrollments

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,4 +3,5 @@ disable=
 	unused-argument,
 	no-self-use,
 	too-few-public-methods,
-	fixme
+	fixme,
+	line-too-long

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -7,26 +7,12 @@ Backend for the create_edxapp_user that works under the open-release/hawthorn.be
 from __future__ import absolute_import, unicode_literals
 from enrollment import api
 from enrollment.errors import CourseModeNotFoundError
-from enrollment.errors import (
-    CourseEnrollmentClosedError,
-    CourseEnrollmentExistsError,
-    CourseEnrollmentFullError,
-    InvalidEnrollmentAttribute,
-    UserNotFoundError
-)
-from openedx.core.lib.exceptions import CourseNotFoundError
+from enrollment.errors import CourseEnrollmentExistsError
 from course_modes.models import CourseMode
 from rest_framework.exceptions import APIException
 from opaque_keys.edx.keys import CourseKey
 from django.contrib.auth.models import User
-from six import text_type
-from student.models import (
-    AlreadyEnrolledError,
-    CourseEnrollment,
-    CourseFullError,
-    EnrollmentClosedError,
-    NonExistentCourseError
-)
+from student.models import CourseEnrollment
 import logging
 
 log = logging.getLogger(__name__)
@@ -51,45 +37,28 @@ def create_enrollment(*args, **kwargs):
             raise APIException('No user found with that email')
         else:
             username = match.username
+
     try:
-
-        if force_registration:
-            # code copied from edx-platform/common/djangoapps/enrollment/data.py@create_course_enrollment
-            # the only change is check_access=True to check_access=False and remove "return" keyword
-            # (Open edx version=0.10)
-            course_key = CourseKey.from_string(course_id)
-            try:
-                user = User.objects.get(username=username)
-            except User.DoesNotExist:
-                msg = u"Not user with username '{username}' found.".format(username=username)
-                log.warn(msg)
-                raise UserNotFoundError(msg)
-            try:
-                enrollment = CourseEnrollment.enroll(user, course_key, check_access=False)
-                api._data_api()._update_enrollment(enrollment, is_active=is_active, mode=mode)
-            except NonExistentCourseError as err:
-                raise CourseNotFoundError(text_type(err))
-            except EnrollmentClosedError as err:
-                raise CourseEnrollmentClosedError(text_type(err))
-            except CourseFullError as err:
-                raise CourseEnrollmentFullError(text_type(err))
-            except AlreadyEnrolledError as err:
-                enrollment = api._data_api().get_course_enrollment(username, course_id)
-                raise CourseEnrollmentExistsError(text_type(err), enrollment)
-            # code copy ends
-        else:
-            # if force registration is false we just call the open edx-platform function create_course_enrollment
-            enrollment = api._data_api().create_course_enrollment(username, course_id, mode, is_active)
-
-        if enrollment_attributes is not None:
-            api.set_enrollment_attributes(username, course_id, enrollment_attributes)
+        enrollment = api._data_api().create_course_enrollment(username, course_id, mode, is_active)
     except CourseEnrollmentExistsError as e:
         if force_registration:
             enrollment = api._data_api().update_course_enrollment(username, course_id, mode, is_active)
         else:
             raise APIException(repr(e) + ", use force_registration to update the existing enrollment")
-    except (UserNotFoundError, InvalidEnrollmentAttribute, CourseNotFoundError, CourseEnrollmentFullError, CourseEnrollmentClosedError) as e:
-        raise APIException(repr(e))
+    except Exception as e:
+        if force_registration:
+            try:
+                course_key = CourseKey.from_string(course_id)
+                user = User.objects.get(username=username)
+                enrollment = CourseEnrollment.enroll(user, course_key, check_access=False)
+                api._data_api()._update_enrollment(enrollment, is_active=is_active, mode=mode)
+            except Exception as e:
+                raise APIException(repr(e))
+        else:
+            raise APIException(repr(e))
+
+    if enrollment_attributes is not None:
+        api.set_enrollment_attributes(username, course_id, enrollment_attributes)
 
     return enrollment, errors
 

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -84,11 +84,13 @@ def _create_or_update_enrollment(username, course_id, mode, is_active, try_updat
 
 
 def _force_create_enrollment(username, course_id, mode, is_active):
+    log.info('Calling _force_create_enrollment')
     try:
         course_key = CourseKey.from_string(course_id)
         user = User.objects.get(username=username)
         enrollment = CourseEnrollment.enroll(user, course_key, check_access=False)
         api._data_api()._update_enrollment(enrollment, is_active=is_active, mode=mode)
     except Exception as e:
+        log.warn('API call failed: {}, {}, {}, {}, {}'.format(repr(e), username, course_id, mode, is_active))
         raise APIException(repr(e))
     return enrollment

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -17,7 +17,19 @@ from enrollment.errors import (
 from openedx.core.lib.exceptions import CourseNotFoundError
 from course_modes.models import CourseMode
 from rest_framework.exceptions import APIException
-from django.contrib.auth import get_user_model
+from opaque_keys.edx.keys import CourseKey
+from django.contrib.auth.models import User
+from six import text_type
+from student.models import (
+    AlreadyEnrolledError,
+    CourseEnrollment,
+    CourseFullError,
+    EnrollmentClosedError,
+    NonExistentCourseError
+)
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def create_enrollment(*args, **kwargs):
@@ -34,13 +46,41 @@ def create_enrollment(*args, **kwargs):
     if validation_errors:
         return None, [", ".join(validation_errors)]
     if email:
-        match = get_user_model().objects.filter(email=email).first()
+        match = User.objects.filter(email=email).first()
         if match is None:
             raise APIException('No user found with that email')
         else:
             username = match.username
     try:
-        enrollment = api._data_api().create_course_enrollment(username, course_id, mode, is_active)
+
+        if force_registration:
+            # code copied from edx-platform/common/djangoapps/enrollment/data.py@create_course_enrollment
+            # the only change is check_access=True to check_access=False and remove "return" keyword
+            # (Open edx version=0.10)
+            course_key = CourseKey.from_string(course_id)
+            try:
+                user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                msg = u"Not user with username '{username}' found.".format(username=username)
+                log.warn(msg)
+                raise UserNotFoundError(msg)
+            try:
+                enrollment = CourseEnrollment.enroll(user, course_key, check_access=False)
+                api._data_api()._update_enrollment(enrollment, is_active=is_active, mode=mode)
+            except NonExistentCourseError as err:
+                raise CourseNotFoundError(text_type(err))
+            except EnrollmentClosedError as err:
+                raise CourseEnrollmentClosedError(text_type(err))
+            except CourseFullError as err:
+                raise CourseEnrollmentFullError(text_type(err))
+            except AlreadyEnrolledError as err:
+                enrollment = api._data_api().get_course_enrollment(username, course_id)
+                raise CourseEnrollmentExistsError(text_type(err), enrollment)
+            # code copy ends
+        else:
+            # if force registration is false we just call the open edx-platform function create_course_enrollment
+            enrollment = api._data_api().create_course_enrollment(username, course_id, mode, is_active)
+
         if enrollment_attributes is not None:
             api.set_enrollment_attributes(username, course_id, enrollment_attributes)
     except CourseEnrollmentExistsError as e:
@@ -50,6 +90,7 @@ def create_enrollment(*args, **kwargs):
             raise APIException(repr(e) + ", use force_registration to update the existing enrollment")
     except (UserNotFoundError, InvalidEnrollmentAttribute, CourseNotFoundError, CourseEnrollmentFullError, CourseEnrollmentClosedError) as e:
         raise APIException(repr(e))
+
     return enrollment, errors
 
 

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -3,23 +3,25 @@
 """
 Backend for the create_edxapp_user that works under the open-release/hawthorn.beta1 tag
 """
-
+# pylint: disable=import-error, protected-access
 from __future__ import absolute_import, unicode_literals
+import logging
+from django.contrib.auth.models import User
 from enrollment import api
 from enrollment.errors import CourseModeNotFoundError
 from enrollment.errors import CourseEnrollmentExistsError
 from course_modes.models import CourseMode
 from rest_framework.exceptions import APIException
 from opaque_keys.edx.keys import CourseKey
-from django.contrib.auth.models import User
 from student.models import CourseEnrollment
-import logging
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 def create_enrollment(*args, **kwargs):
-
+    """
+    backend function to create enrollment
+    """
     errors = []
     email = kwargs.get("email")
     username = kwargs.get('username')
@@ -40,11 +42,11 @@ def create_enrollment(*args, **kwargs):
 
     try:
         enrollment = _create_or_update_enrollment(username, course_id, mode, is_active, force_registration)
-    except Exception as e:
+    except Exception as err:  # pylint: disable=broad-except
         if force_registration:
             enrollment = _force_create_enrollment(username, course_id, mode, is_active)
         else:
-            raise APIException(repr(e))
+            raise APIException(repr(err))
 
     if enrollment_attributes is not None:
         api.set_enrollment_attributes(username, course_id, enrollment_attributes)
@@ -52,7 +54,11 @@ def create_enrollment(*args, **kwargs):
     return enrollment, errors
 
 
+# pylint: disable=invalid-name
 def check_edxapp_enrollment_is_valid(*args, **kwargs):
+    """
+    backend function to check if enrollment is valid
+    """
     errors = []
     is_active = kwargs.get("is_active", True)
     course_id = kwargs.get("course_id")
@@ -73,24 +79,30 @@ def check_edxapp_enrollment_is_valid(*args, **kwargs):
 
 
 def _create_or_update_enrollment(username, course_id, mode, is_active, try_update):
+    """
+    non-forced create or update enrollment internal function
+    """
     try:
         enrollment = api._data_api().create_course_enrollment(username, course_id, mode, is_active)
-    except CourseEnrollmentExistsError as e:
+    except CourseEnrollmentExistsError as err:
         if try_update:
             enrollment = api._data_api().update_course_enrollment(username, course_id, mode, is_active)
         else:
-            raise Exception(repr(e) + ", use force_registration to update the existing enrollment")
+            raise Exception(repr(err) + ", use force_registration to update the existing enrollment")
     return enrollment
 
 
 def _force_create_enrollment(username, course_id, mode, is_active):
-    log.info('Calling _force_create_enrollment')
+    """
+    forced create enrollment internal function
+    """
+    LOG.info('Calling _force_create_enrollment')
     try:
         course_key = CourseKey.from_string(course_id)
         user = User.objects.get(username=username)
         enrollment = CourseEnrollment.enroll(user, course_key, check_access=False)
         api._data_api()._update_enrollment(enrollment, is_active=is_active, mode=mode)
-    except Exception as e:
-        log.warn('API call failed: {}, {}, {}, {}, {}'.format(repr(e), username, course_id, mode, is_active))
-        raise APIException(repr(e))
+    except Exception as err:  # pylint: disable=broad-except
+        LOG.warn('API call failed: %s, %s, %s, %s, %s', repr(err), username, course_id, mode, is_active)
+        raise APIException(repr(err))
     return enrollment


### PR DESCRIPTION
We had to copy the internals of the create_course_enrollment function to use check_access=False instead of check_access=True when calling CourseEnrollment.enroll