### PR TITLE
Command order was wrong on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ make dev.checkout
 make dev.clone
 make dev.provision
 make dev.provision
-direnv allow .
 echo export OPENEDX_RELEASE=hawthorn.master > .envrc
+direnv allow .
 cd ~/Documents/eoxstack/src/
 # Instructions for installing eox-core
 sudo mkdir edxapp


### PR DESCRIPTION
Bash commands order was wrong (throws direnv: error .envrc file not found) now its not.