### PR TITLE
Missing "make dev.up" on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ make dev.provision
 make dev.provision
 direnv allow .
 echo export OPENEDX_RELEASE=hawthorn.master > .envrc
+make dev.up
 cd ~/Documents/eoxstack/src/
 # Instructions for installing eox-core
 sudo mkdir edxapp


### PR DESCRIPTION
Missing "make dev.up" on README.md. Adding it