### PR TITLE
anmrdz/support extra fields

### DIFF
--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -46,6 +46,7 @@ class EdxappUser(APIView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         data['site'] = get_current_site(request)
+        data['request'] = request
         user, msg = create_edxapp_user(**data)
 
         serialized_user = EdxappUserSerializer(user)


### PR DESCRIPTION
###  Add support for extra_fields and extended_profile_fields in eox_core API

### **Description**

The purpose of this PR is to expand user creation API by having these features: 
- Enable extra_fields support in the creation, the extra fields  are  level_of_education,  gender, mailing_address, city, country, goals, and year_of_birth
- Enable extended_profile_fields, this refers to the field 'meta' in the user profile.
- Open the possibility to a refined control of the user creation flow such as :
	- Send verification email
	- Enable discussion notification emails
	- Create comment client
	- Allow third-party authentication  (social media providers)
	- Allow external authentication

The proposed Json structure would be like: 
`data = {
        'email': "address@example.org",
        'username': "Username",
        'password': "P4ssW0rd",
        'fullname': "Full Name",
        'activate': True,
        'site': request.site,
        'language_preference': 'es-419',
        'extended_profile_fields': {
            'internal_id': '12',
            ...
        },
        'year_of_birth': '1981',
        'city': 'Boston',
        'verify_account_email': True,
        'enable_comments_service': True
    }`

The way to achieve this is using the open-Edx  function [create_account_with_parms](https://github.com/eduNEXT/edunext-platform/blob/6851b666a144a9f1cd4a73ee0c51ccc3046972f8/common/djangoapps/student/views/management.py#L585)   , this allows us to leverage the maintenance of this code but will share the same issues : 

>     Issues with this code:
>     * It is non-transactional except where explicitly wrapped in atomic to
>       alleviate deadlocks and improve performance. This means failures at different places in registration
>      can leave users in inconsistent states.
>     * Third-party auth passwords are not verified. There is a comment that
>       they are unused, but it would be helpful to have a sanity check that they are sane.
>     * The user-facing text is rather unfriendly (e.g. "Username must be a
>       minimum of two characters long" rather than "Please use a username of at least two characters").
>     * Duplicate email raises a ValidationError (rather than the expected
>       AccountValidationError). Duplicate username returns an inconsistent
>       user message (i.e. "An account with the Public Username '{username}'
>       already exists." rather than "It looks like {username} belongs to an
>       existing account. Try again with a different username.") The two checks
>       occur at different places in the code; as a result, registering with
>       both a duplicate username and email raises only a ValidationError for
>       email only.

### **Work in Progress**
-  Transform scripts into unitary test inside eox-core
-  Handle format errors in expected fields
-  Display errors generated in create_account_with_parms as the request response
-  Make sure all configurations are restored after monkey patching


### **Testing**

`curl -X POST --header "Authorization: Bearer <AUTH_TOKEN> " -H "Accept: application/json" \
	http://edx.devstack.lms:18000/eox-core/api/v1/user/ --header "Content-Type: application/json" \
	--data '{"username": "eox2test", "email": "eox2test@example.com", "password": "qwerty123",
	"fullname": "JJ Smith", "gender":"f", "extended_profile_fields":{"pet":"dog", "internal_id":"12"}, "city":"Buenos Aires", "country":"AR", "level_of_education": "p"}'`

This would create a user with extra_fields and extended_profile fields. if no verify_account_email nor enable_comments_service are present these steps would be skipped. 

![image](https://user-images.githubusercontent.com/9253943/57886621-3d41ee00-77f3-11e9-9d3c-2bc2c6bcb5c1.png)


### **Reviewers**

- [ ] @felipemontoya 

- [ ] @diegomillan 