### PR TITLE
Add update_user to User API 

### DIFF
--- a/eox_core/api/v1/tests/test_users.py
+++ b/eox_core/api/v1/tests/test_users.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Test module for Users API under the open-release/hawthorn.beta1 tag
+"""
+from mock import patch, Mock
+from django.test import TestCase
+from rest_framework.exceptions import NotFound
+from django.contrib.auth.models import User
+
+from rest_framework.test import APIClient
+
+
+class UserAPITest(TestCase):
+    """ Tests for the User API """
+
+    patch_permissions = patch('eox_core.api.v1.permissions.EoxCoreAPIPermission.has_permission', return_value=True)
+
+    def setUp(self):
+        """ setup """
+        super(UserAPITest, self).setUp()
+        self.api_user = User(1, 'api_client@example.com', 'client')
+        self.client = APIClient()
+        self.url = '/api/v1/user/'
+        self.client.force_authenticate(user=self.api_user)
+        self.data = {
+            "username": "test",
+            "bio": "...",
+            "name": "Test t",
+            "country": "TestLand",
+            "year_of_birth": 1880,
+        }
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_get_validation(self, m_get_edxapp_user, *_):
+        """ Test the paremeter validation of the GET method"""
+        m_get_edxapp_user.return_value = None
+
+        # Test empty request
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Email', response.data[0])
+        self.assertIn('username', response.data[0])
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_get_invalid_user(self, m_get_edxapp_user, *_):
+        """ Test the GET method fails for an invalid user"""
+        params = {
+            'email': 'test@test.com',
+        }
+
+        m_get_edxapp_user.side_effect = NotFound('No user found by {query} on site example.com.'.format(query=str(params)))
+
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 404)
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.EdxappUserReadOnlySerializer')
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_get(self, m_get_edxapp_user, m_EdxappUserReadOnlySerializer, *_):
+        """ Test that the GET method works under normal conditions """
+        m_get_edxapp_user.return_value = Mock()
+        m_EdxappUserReadOnlySerializer.return_value = self
+
+        params = {
+            'username': 'test',
+        }
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(self.data, response.data)
+        m_get_edxapp_user.assert_called_once_with(**params)
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.delete_edxapp_user')
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_delete_invalid_user(self, m_get_edxapp_user, m_delete_edxapp_user, *_):
+        """ Test the DELETE method fails for an invalid user"""
+        params = {
+            'email': 'test@test.com',
+        }
+
+        m_get_edxapp_user.side_effect = NotFound('No user found by {query} on site example.com.'.format(query=str(params)))
+
+        response = self.client.delete(self.url, params)
+        self.assertEqual(response.status_code, 404)
+        m_delete_edxapp_user.assert_not_called()
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.delete_edxapp_user')
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_delete(self, m_get_edxapp_user, m_delete_edxapp_user, *_):
+        """ Test that the DELETE method works under normal conditions """
+        m_user = User(2, 'test@example.com', 'test')
+        m_get_edxapp_user.return_value = m_user
+        m_delete_edxapp_user.return_value = None
+
+        params = {
+            'username': 'test',
+        }
+        response = self.client.delete(self.url, params)
+        self.assertEqual(response.status_code, 204)
+        m_get_edxapp_user.assert_called_once_with(**params)
+        m_delete_edxapp_user.assert_called_once_with(m_user)
+
+    @patch_permissions
+    @patch('eox_core.api.v1.views.EdxappUserReadOnlySerializer')
+    @patch('eox_core.api.v1.views.update_edxapp_user')
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    def test_api_put(self, m_get_edxapp_user, m_update_edxapp_user, m_EdxappUserReadOnlySerializer, *_):
+        """ Test that the PUT method works under normal conditions """
+        m_user = User(2, 'test@example.com', 'test')
+        self.data['name'] = 'Updated name'
+        m_EdxappUserReadOnlySerializer.return_value = self
+        m_get_edxapp_user.return_value = m_user
+        m_update_edxapp_user.return_value = None
+
+        params = {
+            'username': 'test',
+            'name': 'Updated name',
+        }
+
+        response = self.client.put(self.url, data=params, format='json')
+        self.assertEqual(response.status_code, 200)
+        m_get_edxapp_user.assert_called_once()
+        self.assertDictContainsSubset(self.data, response.data)
+        m_update_edxapp_user.assert_called_once_with(m_user, name='Updated name')

--- a/eox_core/api/v1/tests/test_users.py
+++ b/eox_core/api/v1/tests/test_users.py
@@ -1,24 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Test module for Users API under the open-release/hawthorn.beta1 tag
+Test module for Users API.
 """
-from mock import patch, Mock
-
-from django.test import TestCase
 from django.contrib.auth.models import User
-
+from django.test import TestCase
+from mock import Mock, patch
 from rest_framework.exceptions import NotFound
 from rest_framework.test import APIClient
 
 
 class UserAPITest(TestCase):
-    """ Tests for the User API """
+    """ Tests for the User API. """
 
     patch_permissions = patch('eox_core.api.v1.permissions.EoxCoreAPIPermission.has_permission', return_value=True)
 
     def setUp(self):
-        """ setup """
+        """ Setup. """
         super(UserAPITest, self).setUp()
         self.api_user = User(1, 'api_client@example.com', 'client')
         self.client = APIClient()
@@ -35,7 +33,7 @@ class UserAPITest(TestCase):
     @patch_permissions
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_get_validation(self, m_get_edxapp_user, *_):
-        """ Test the paremeter validation of the GET method"""
+        """ Test the paremeter validation of the GET method. """
         m_get_edxapp_user.return_value = None
 
         # Test empty request
@@ -47,7 +45,7 @@ class UserAPITest(TestCase):
     @patch_permissions
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_get_invalid_user(self, m_get_edxapp_user, *_):
-        """ Test the GET method fails for an invalid user"""
+        """ Test the GET method fails for an invalid user. """
         params = {
             'email': 'test@test.com',
         }
@@ -61,7 +59,7 @@ class UserAPITest(TestCase):
     @patch('eox_core.api.v1.views.EdxappUserReadOnlySerializer')
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_get(self, m_get_edxapp_user, m_EdxappUserReadOnlySerializer, *_):  # pylint: disable=invalid-name
-        """ Test that the GET method works under normal conditions """
+        """ Test that the GET method works under normal conditions. """
         m_get_edxapp_user.return_value = Mock()
         m_EdxappUserReadOnlySerializer.return_value = self
 
@@ -77,7 +75,7 @@ class UserAPITest(TestCase):
     @patch('eox_core.api.v1.views.delete_edxapp_user')
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_delete_invalid_user(self, m_get_edxapp_user, m_delete_edxapp_user, *_):
-        """ Test the DELETE method fails for an invalid user"""
+        """ Test the DELETE method fails for an invalid user. """
         params = {
             'email': 'test@test.com',
         }
@@ -92,7 +90,7 @@ class UserAPITest(TestCase):
     @patch('eox_core.api.v1.views.delete_edxapp_user')
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_delete(self, m_get_edxapp_user, m_delete_edxapp_user, *_):
-        """ Test that the DELETE method works under normal conditions """
+        """ Test that the DELETE method works under normal conditions. """
         m_user = User(2, 'test@example.com', 'test')
         m_get_edxapp_user.return_value = m_user
         m_delete_edxapp_user.return_value = None
@@ -110,7 +108,7 @@ class UserAPITest(TestCase):
     @patch('eox_core.api.v1.views.update_edxapp_user')
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_put(self, m_get_edxapp_user, m_update_edxapp_user, m_EdxappUserReadOnlySerializer, *_):  # pylint: disable=invalid-name
-        """ Test that the PUT method works under normal conditions """
+        """ Test that the PUT method works under normal conditions. """
         m_user = User(2, 'test@example.com', 'test')
         self.data['name'] = 'Updated name'
         m_EdxappUserReadOnlySerializer.return_value = self
@@ -133,7 +131,7 @@ class UserAPITest(TestCase):
     def test_api_put_force_validation(self, m_get_edxapp_user, *_):
         """
         Test that the PUT method validates a reason is given when setting
-        the force param to change email or password
+        the force param to change email or password.
         """
         m_user = User(2, 'test@example.com', 'test')
         m_get_edxapp_user.return_value = m_user
@@ -154,7 +152,7 @@ class UserAPITest(TestCase):
     @patch('eox_core.api.v1.views.update_edxapp_user')
     @patch('eox_core.api.v1.views.get_edxapp_user')
     def test_api_put_force(self, m_get_edxapp_user, m_update_edxapp_user, m_EdxappUserReadOnlySerializer, *_):  # pylint: disable=invalid-name
-        """ Test that the PUT method with force works under normal conditions """
+        """ Test that the PUT method with force works under normal conditions. """
         m_user = User(2, 'test@example.com', 'test')
         self.data['email'] = 'updated_test@example.com'
         m_EdxappUserReadOnlySerializer.return_value = self

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -149,14 +149,10 @@ class EdxappUser(UserQueryMixin, APIView):
         user_query = self.get_user_query(request)
         user = get_edxapp_user(**user_query)
         update_request = request.data
-        # Exclude fields that can't be updated
-        for key in user_query:
-            if key in update_request:
-                update_request.pop(key)
-
-        LOG.info('Admin user: %s updated user: %s, site:%s,  update_params:%s ', request.auth.user, user.username, self.site, str(update_request))
+        update_request.pop('username')
         update_edxapp_user(user, **update_request)
         response_data = self.get_serialized_user(request, user)
+        LOG.info('Admin user: %s updated user: %s, site:%s,  update_params:%s ', request.auth.user, user.username, self.site, str(update_request))
 
         return Response(response_data)
 

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -30,6 +30,7 @@ from eox_core.edxapp_wrapper.users import (
     create_edxapp_user,
     get_edxapp_user,
     update_edxapp_user,
+    delete_edxapp_user,
 )
 
 
@@ -114,6 +115,7 @@ class UserQueryMixin(object):
         serialized_user = EdxappUserReadOnlySerializer(user, custom_fields=admin_fields, context={'request': request})
         return serialized_user.data
 
+
 class EdxappUser(UserQueryMixin, APIView):
     """
     Handles API requests to create users
@@ -154,6 +156,17 @@ class EdxappUser(UserQueryMixin, APIView):
         response_data = self.get_serialized_user(request, user)
 
         return Response(response_data)
+
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete an user means inactive the user thus isolating it from the openedx plataform,
+        no data is actually deleted
+        """
+        user_query = self.get_user_query(request)
+        user = get_edxapp_user(**user_query)
+        delete_edxapp_user(user)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get(self, request, *args, **kwargs):
         """

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -25,7 +25,14 @@ from eox_core.api.v1.serializers import (
     EdxappUserReadOnlySerializer,
     EdxappCoursePreEnrollmentSerializer,
 )
-from eox_core.edxapp_wrapper.users import create_edxapp_user, get_edxapp_user
+
+from eox_core.edxapp_wrapper.users import (
+    create_edxapp_user,
+    get_edxapp_user,
+    update_edxapp_user,
+)
+
+
 from eox_core.edxapp_wrapper.enrollments import (
     create_enrollment,
     update_enrollment,
@@ -123,6 +130,18 @@ class EdxappUser(UserQueryMixin, APIView):
         response_data = serialized_user.data
         if msg:
             response_data["messages"] = msg
+        return Response(response_data)
+
+    def put(self, request, *args, **kwargs):
+        """
+        Update the user on edxapp
+        """
+        data = request.data
+        data['site'] = get_current_site(request)
+        msg = update_edxapp_user(**data)
+
+        if msg:
+            response_data = msg
         return Response(response_data)
 
     def get(self, request, *args, **kwargs):

--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -171,11 +171,14 @@ def update_edxapp_user(user, **kwargs):
 
 def delete_edxapp_user(user):
     """
-    Delete an user means inactive the user thus isolating it from the openedx plataform,
-    no data is actually deleted
+    Delete an user as a first approach means inactive the user thus isolating
+    it from the openedx plataform, no data is actually deleted
     """
     try:
         user.is_active = False
+        retired_email = user.email
+        retired_email = retired_email.replace(u'@', u'+')
+        user.email = '{}@retired.edunext.co'.format(retired_email)
         user.save()
     except Exception:  # pylint: disable=broad-except
         raise NotFound("The deletion could not be completed")

--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.user_api.accounts.api import (  # pylint: disable=i
     check_account_exists,
     update_account_settings,
 )
-from openedx.core.djangoapps.user_api.errors import ( # pylint: disable=import-error
+from openedx.core.djangoapps.user_api.errors import (  # pylint: disable=import-error
     AccountUpdateError,
     AccountValidationError,
 )
@@ -134,6 +134,7 @@ def create_edxapp_user(*args, **kwargs):
 
     return user, errors
 
+
 def update_edxapp_user(user, **kwargs):
     """
     Update a user on the open edx django site using calls to
@@ -166,6 +167,19 @@ def update_edxapp_user(user, **kwargs):
             raise NotFound("Error: the update could not be processed, please review your request ")
 
     return user
+
+
+def delete_edxapp_user(user):
+    """
+    Delete an user means inactive the user thus isolating it from the openedx plataform,
+    no data is actually deleted
+    """
+    try:
+        user.is_active = False
+        user.save()
+    except Exception:  # pylint: disable=broad-except
+        raise NotFound("The deletion could not be completed")
+
 
 def get_edxapp_user(**kwargs):
     """

--- a/eox_core/edxapp_wrapper/tests/test_users.py
+++ b/eox_core/edxapp_wrapper/tests/test_users.py
@@ -5,7 +5,12 @@ import mock
 
 from django.conf import settings
 from django.test import TestCase
-from ..users import create_edxapp_user
+from ..users import (
+    create_edxapp_user,
+    delete_edxapp_user,
+    update_edxapp_user,
+    get_edxapp_user,
+)
 
 
 class CreateEdxappUserTest(TestCase):
@@ -31,3 +36,12 @@ class CreateEdxappUserTest(TestCase):
 
         create_edxapp_user(data)
         m_user_backend.create_edxapp_user.assert_called_with(data)
+
+        update_edxapp_user(data)
+        m_user_backend.update_edxapp_user.assert_called_with(data)
+
+        delete_edxapp_user(data)
+        m_user_backend.delete_edxapp_user.assert_called_with(data)
+
+        get_edxapp_user(data)
+        m_user_backend.get_edxapp_user.assert_called_with(data)

--- a/eox_core/edxapp_wrapper/tests/test_users.py
+++ b/eox_core/edxapp_wrapper/tests/test_users.py
@@ -8,8 +8,8 @@ from django.test import TestCase
 from ..users import (
     create_edxapp_user,
     delete_edxapp_user,
-    update_edxapp_user,
     get_edxapp_user,
+    update_edxapp_user,
 )
 
 

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -27,7 +27,7 @@ def create_edxapp_user(*args, **kwargs):
 
 
 def update_edxapp_user(*args, **kwargs):
-    """ Update the edxapp user """
+    """ Update the edxapp user. """
 
     backend_function = settings.EOX_CORE_USERS_BACKEND
     backend = import_module(backend_function)
@@ -36,7 +36,7 @@ def update_edxapp_user(*args, **kwargs):
 
 
 def delete_edxapp_user(*args, **kwargs):
-    """ Delete the edxapp user """
+    """ Delete the edxapp user. """
 
     backend_function = settings.EOX_CORE_USERS_BACKEND
     backend = import_module(backend_function)

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -25,6 +25,14 @@ def create_edxapp_user(*args, **kwargs):
 
     return backend.create_edxapp_user(*args, **kwargs)
 
+def update_edxapp_user(*args, **kwargs):
+    """ Update the edxapp user """
+
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.update_edxapp_user(*args, **kwargs)
+
 
 def get_user_read_only_serializer(*args, **kwargs):
     """ Gets the Open edX model UserProfile """

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -25,6 +25,7 @@ def create_edxapp_user(*args, **kwargs):
 
     return backend.create_edxapp_user(*args, **kwargs)
 
+
 def update_edxapp_user(*args, **kwargs):
     """ Update the edxapp user """
 
@@ -32,6 +33,15 @@ def update_edxapp_user(*args, **kwargs):
     backend = import_module(backend_function)
 
     return backend.update_edxapp_user(*args, **kwargs)
+
+
+def delete_edxapp_user(*args, **kwargs):
+    """ Delete the edxapp user """
+
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.delete_edxapp_user(*args, **kwargs)
 
 
 def get_user_read_only_serializer(*args, **kwargs):

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -40,6 +40,7 @@ def plugin_settings(settings):
     settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT = 1000
     settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = True
     settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = ['fetch_from_unfiltered_table', ]
+    settings.EOX_CORE_USER_EMAIL_RETIRED_SUFFIX = 'retired.edunext.co'
 
     if settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
         settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = [


### PR DESCRIPTION
###  Complete CRUD for User API

### **Description**

The purpose of this PR is to add the missing CRUD functions to the User. 

- [x] Update user

It is possible to update all the fields that are not marked as read-only in the configuration such as: 
- bio
- name
- country
- social_links
- extended_profile
- year_of_birth
- level_of_education
- goals
- language_proficiencies
- gender
- account_privacy
- mailing_address
- email
- password

In order to update sensible fields as email and password is necessary to set the 'force' param and provide a reason of the cause of the change.

- the new_password is validated using [validate_password](https://github.com/eduNEXT/edunext-platform/blob/6851b666a144a9f1cd4a73ee0c51ccc3046972f8/common/djangoapps/util/password_policy_validators.py#L152)
- the new_email is directly changed, no confirmation email is sent to the final user.

- [x] Delete user

It is only implemented as a first approach in which the user is isolated by deactivating it and retiring its email, no actual deletion of data is being done.

- [x] Standardize using UserQueryMixin

- [x] Log actions of admin/client

### **Reviewers**

- [ ] @felipemontoya 

- [ ] @diegomillan 

- [ ] @Squirrel18  

- [ ] @andrey-canon  