### PR TITLE
anmrdz/fix crud enrollments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             make python-quality-test
             make javascript-quality-test
             coverage run --source="." -m pytest ./eox_core
-            coverage report --fail-under=60
+            coverage report --fail-under=60 -m
 
       - store_artifacts:
           path: test-reports
@@ -108,7 +108,7 @@ jobs:
             make python-quality-test
             make javascript-quality-test
             coverage run --source="." -m pytest ./eox_core
-            coverage report --fail-under=60 --rcfile=.coveragerc
+            coverage report --fail-under=60 --rcfile=.coveragerc -m
 
       - store_artifacts:
           path: test-reports

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -69,7 +69,6 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     user = serializers.CharField(max_length=30, default=None)
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
-    email = serializers.CharField(max_length=255, default=None)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
     course_id = serializers.CharField(max_length=255, default=None)
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -69,6 +69,9 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     user = serializers.CharField(max_length=30, default=None)
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
+    email = serializers.CharField(max_length=255, default=None)
+    enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
+    course_id = serializers.CharField(max_length=255, default=None)
 
     def validate(self, attrs):
         """
@@ -86,11 +89,8 @@ class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     on different backends
     """
     username = serializers.CharField(max_length=30, default=None)
-    email = serializers.CharField(max_length=255, default=None)
     force = serializers.BooleanField(default=False)
-    course_id = serializers.CharField(max_length=255, default=None)
     bundle_id = serializers.CharField(max_length=255, default=None)
-    enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
 
 
 def EdxappUserReadOnlySerializer(*args, **kwargs):   # pylint: disable=invalid-name

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -66,7 +66,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
 
     """
 
-    user = serializers.CharField(max_length=30, default=None)
+    username = serializers.CharField(max_length=30, default=None, source='user')
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])

--- a/eox_core/api/v1/tests/__init__.py
+++ b/eox_core/api/v1/tests/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """ . """
-from mock import patch, Mock
+from mock import patch
 from django.test import TestCase
 from django.contrib.auth.models import User
 
@@ -114,7 +114,7 @@ class TestEnrollmentsAPI(TestCase):
             'user': 'test',  # this is the source value for the username field in the serializer
             'course_id': 'course-v1:org+course+run',
             'is_active': True,
-        },{
+        }, {
             'mode': 'audit',
             'user': 'test',
             'course_id': 'course-v1:org+course_2+run',

--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+""" . """
+from mock import patch
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from rest_framework.test import APIClient
+
+
+class TestEnrollmentsAPI(TestCase):
+    """ Tests for the enrollments endpoints """
+
+    patch_permissions = patch('eox_core.api.v1.permissions.EoxCoreAPIPermission.has_permission', return_value=True)
+
+    def setUp(self):
+        """ setup """
+        super(TestEnrollmentsAPI, self).setUp()
+        self.api_user = User('test', 'test@example.com', 'test')
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.api_user)
+
+    @patch_permissions
+    def test_api_get_validation(self, _):
+        """ Test that the GET method requires some parameters """
+        response = self.client.get('/api/v1/enrollment/')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('course_id', response.data[0])
+
+        params = {
+            'course_id': 'course-v1:org+course+run',
+        }
+        response = self.client.get('/api/v1/enrollment/', params)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('username', response.data[0])
+
+    @patch('eox_core.api.v1.views.get_enrollment')
+    @patch('eox_core.api.v1.views.get_edxapp_user')
+    @patch_permissions
+    def test_api_get(self, _, m_get_user, m_get_enrollment):
+        """ Test that the GET method works under normal conditions """
+        m_get_user.return_value.username = 'testusername'
+        m_get_enrollment.return_value = None, None
+
+        params = {
+            'course_id': 'course-v1:org+course+run',
+            'username': 'testusername',
+        }
+        response = self.client.get('/api/v1/enrollment/', params)
+        self.assertEqual(response.status_code, 200)
+
+        m_get_user.assert_called_once_with(username='testusername')
+        m_get_enrollment.assert_called_once_with(
+            username='testusername',
+            course_id='course-v1:org+course+run',
+        )

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -206,8 +206,11 @@ class UserInfo(APIView):
             # `django.contrib.auth.User` instance.
             'user': six.text_type(request.user.username),
             'email': six.text_type(request.user.email),
-            'is_staff': request.user.is_staff,
-            'is_superuser': request.user.is_superuser,
             'auth': six.text_type(request.auth)
         }
+
+        if request.user.is_staff:
+            content['is_superuser'] = request.user.is_superuser
+            content['is_staff'] = request.user.is_staff
+
         return Response(content)

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -83,7 +83,13 @@ class EdxappEnrollment(APIView):
     permission_classes = (EoxCoreAPIPermission,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
-    # pylint: disable=too-many-locals
+    def __init__(self, *args, **kwargs):
+        """
+        Defines instance attributes
+        """
+        super(EdxappEnrollment, self).__init__(*args, **kwargs)
+        self.query_params = None
+
     def post(self, request, *args, **kwargs):
         """
         Creates the users on edxapp

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -5,7 +5,8 @@ API v1 views.
 from __future__ import absolute_import, unicode_literals
 import logging
 
-from rest_framework.views import APIView
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import ValidationError, NotFound, APIException
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
@@ -163,27 +164,10 @@ class EdxappEnrollment(APIView):
         """
         Handle exception: log it
         """
-        self.log('API Error', self.kwargs, exc)
-        return super(EdxappEnrollment, self).handle_exception(exc)
+        if isinstance(exc, APIException):
+            LOG.error('API Error: %s', repr(exc.detail))
 
-    def log(self, desc, data, exception=None):
-        """
-        log util for this view
-        """
-        username = data.get('username')
-        bundle_id = data.get('bundle_id')
-        course_id = data.get('course_id')
-        mode = data.get('mode')
-        is_active = data.get('is_active')
-        force = data.get('force')
-        id_val = bundle_id or course_id
-        id_str = 'bundle_id' if bundle_id else 'course_id'
-        logstr = id_str + ': %s, username: %s, mode: %s, is_active: %s, force: %s'
-        logarr = [id_val, username, mode, is_active, force]
-        if exception:
-            LOG.error(desc + ': Exception %s,' + logstr, repr(exception), *logarr)
-        else:
-            LOG.info(desc + ': ' + logstr, *logarr)
+        return super(EdxappEnrollment, self).handle_exception(exc)
 
 
 class UserInfo(APIView):

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -115,9 +115,9 @@ class EdxappEnrollment(APIView):
         if not email and not username:
             raise ValidationError(detail='Email or username needed')
 
-        user_query = {
-            'site': request.site,
-        }
+        user_query = {}
+        if hasattr(request, 'site'):
+            user_query['site'] = request.site
         if username:
             user_query['username'] = username
         elif email:
@@ -134,7 +134,7 @@ class EdxappEnrollment(APIView):
         if errors:
             raise NotFound(detail=errors)
         response = EdxappCourseEnrollmentSerializer(enrollment).data
-        return  Response(response)
+        return Response(response)
 
     def delete(self, request, *args, **kwargs):
         """

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -102,10 +102,13 @@ class EdxappEnrollment(APIView):
         """
         Get enrollments on edxapp
         """
-        data = dict(request.data)
-        course_id = data.get('course_id', None)
-        username = data.get('username', None)
-        email = data.get('email', None)
+        query_params = request.query_params
+        if not query_params and request.data:
+            query_params = request.data
+
+        course_id = query_params.get('course_id', None)
+        username = query_params.get('username', None)
+        email = query_params.get('email', None)
 
         if not course_id:
             raise ValidationError(detail='You have to provide a course_id')

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -88,14 +88,14 @@ class EdxappEnrollment(APIView):
         """
         Creates the users on edxapp
         """
-        data = dict(request.data)
+        data = request.data
         return EdxappEnrollment.prepare_multiresponse(data, create_enrollment)
 
     def put(self, request, *args, **kwargs):
         """
         Update enrollments on edxapp
         """
-        data = dict(request.data)
+        data = request.data
         return EdxappEnrollment.prepare_multiresponse(data, update_enrollment)
 
     def get(self, request, *args, **kwargs):
@@ -140,8 +140,10 @@ class EdxappEnrollment(APIView):
         """
         Delete enrollment on edxapp
         """
-        data = dict(request.data)
-        delete_enrollment(**data)
+        query_params = request.query_params
+        if not query_params and request.data:
+            query_params = request.data
+        delete_enrollment(**query_params)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @staticmethod

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -102,7 +102,19 @@ class EdxappEnrollment(APIView):
         Get enrollments on edxapp
         """
         data = dict(request.data)
-        return EdxappEnrollment.prepare_multiresponse(data, get_enrollment)
+        course_id = data.get('course_id', None)
+        username = data.get('username', None)
+        email = data.get('email', None)
+
+        if not course_id:
+            return Response('You have to provide a course_id', status.HTTP_400_BAD_REQUEST)
+        if not email and not username:
+            return Response('Email or username needed', status.HTTP_400_BAD_REQUEST)
+        enrollment, errors = get_enrollment(**data)
+        if errors:
+            return Response(errors, status.HTTP_404_NOT_FOUND)
+        response = EdxappCourseEnrollmentSerializer(enrollment).data
+        return  Response(response)
 
     def delete(self, request, *args, **kwargs):
         """

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -80,6 +80,7 @@ def update_enrollment(*args, **kwargs):
             raise APIException('No user found with that email')
         else:
             username = match.username
+            email = match.email
     LOG.info('Updating enrollment for student: %s of course: %s mode: %s', username, course_id, mode)
     enrollment = api._data_api().update_course_enrollment(username, course_id, mode, is_active)
     if not enrollment:
@@ -87,6 +88,9 @@ def update_enrollment(*args, **kwargs):
     if enrollment_attributes is not None:
         api.set_enrollment_attributes(username, course_id, enrollment_attributes)
 
+    enrollment['enrollment_attributes'] = enrollment_attributes
+    enrollment['course_id'] = course_id
+    enrollment['email'] = email
     return enrollment, errors
 
 
@@ -187,6 +191,7 @@ def enroll_on_course(course_id, *args, **kwargs):
             raise APIException('No user found with that email')
         else:
             username = match.username
+            email = match.email
 
     try:
         LOG.info('Creating regular enrollment %s, %s, %s', username, course_id, mode)
@@ -203,6 +208,9 @@ def enroll_on_course(course_id, *args, **kwargs):
     if enrollment_attributes is not None:
         api.set_enrollment_attributes(username, course_id, enrollment_attributes)
 
+    enrollment['enrollment_attributes'] = enrollment_attributes
+    enrollment['course_id'] = course_id
+    enrollment['email'] = email
     return enrollment, errors
 
 

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -19,7 +19,6 @@ from course_modes.models import CourseMode
 from enrollment import api
 from enrollment.errors import (CourseEnrollmentExistsError,
                                CourseModeNotFoundError)
-from eox_core.edxapp_wrapper.users import get_edxapp_user
 from eox_core.edxapp_wrapper.backends.edxfuture_i_v1 import get_program
 from eox_core.edxapp_wrapper.users import check_edxapp_account_conflicts
 from openedx.core.djangoapps.content.course_overviews.models import \

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -42,8 +42,10 @@ def create_enrollment(*args, **kwargs):
 
     if program_uuid:
         return enroll_on_program(program_uuid, *args, **kwargs)
+    if course_id:
+        return enroll_on_course(course_id, *args, **kwargs)
 
-    return enroll_on_course(course_id, *args, **kwargs)
+    raise APIException("You have to provide a course_id or bundle_id")
 
 def update_enrollment(*args, **kwargs):
     """
@@ -263,9 +265,7 @@ def check_edxapp_enrollment_is_valid(*args, **kwargs):
     email = kwargs.get("email")
 
     if program_uuid and course_id:
-        return None, ['You have to provide a course_id or bundle_id but not both']
-    if not program_uuid and not course_id:
-        return None, ['You have to provide a course_id or bundle_id']
+        return ['You have to provide a course_id or bundle_id but not both']
     if not email and not username:
         return ['Email or username needed']
     if not check_edxapp_account_conflicts(email=email, username=username):

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -90,7 +90,6 @@ def update_enrollment(*args, **kwargs):
 
     enrollment['enrollment_attributes'] = enrollment_attributes
     enrollment['course_id'] = course_id
-    enrollment['email'] = email
     return enrollment, errors
 
 
@@ -133,7 +132,6 @@ def get_enrollment(*args, **kwargs):
         return None, errors
     enrollment['enrollment_attributes'] = api.get_enrollment_attributes(username, course_id)
     enrollment['course_id'] = course_id
-    enrollment['email'] = email
     return enrollment, errors
 
 def delete_enrollment(*args, **kwargs):
@@ -210,7 +208,6 @@ def enroll_on_course(course_id, *args, **kwargs):
 
     enrollment['enrollment_attributes'] = enrollment_attributes
     enrollment['course_id'] = course_id
-    enrollment['email'] = email
     return enrollment, errors
 
 

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -116,10 +116,10 @@ def get_enrollment(*args, **kwargs):
         LOG.info('Getting enrollment information of student: %s  course: %s', username, course_id)
         enrollment = api.get_enrollment(username, course_id)
         if not enrollment:
-            errors.append('No enrollment found for {}'.format(username))
+            errors.append('No enrollment found for user:`{}`'.format(username))
             return None, errors
     except InvalidKeyError:
-        errors.append('No course found for course_id {}'.format(course_id))
+        errors.append('No course found for course_id `{}`'.format(course_id))
         return None, errors
     enrollment['enrollment_attributes'] = api.get_enrollment_attributes(username, course_id)
     enrollment['course_id'] = course_id
@@ -132,35 +132,27 @@ def delete_enrollment(*args, **kwargs):
     Example:
         >>>delete_enrollment(
             {
-            "username": "Bob",
+            "user": user_object,
             "course_id": course-v1-edX-DemoX-1T2015"
         )
     """
     course_id = kwargs.pop('course_id', None)
-    username = kwargs.get('username', None)
-    email = kwargs.get('email', None)
+    user = kwargs.get('user')
     try:
         course_key = CourseKey.from_string(course_id)
-        if username:
-            user = User.objects.get(username=username)
-        else:
-            user = User.objects.get(email=email)
-    except User.DoesNotExist: # pylint: disable=no-member
-        raise NotFound('No user found by {query} .'.format(query=str(kwargs)))
     except InvalidKeyError:
-        raise NotFound('No course found by course id {} .'.format(course_id))
-
+        raise NotFound('No course found by course id `{}`'.format(course_id))
 
     username = user.username
 
-    LOG.info('Deleting enrollment student: %s  course: %s', username, course_id)
+    LOG.info('Deleting enrollment. User: `%s`  course: `%s`', username, course_id)
     enrollment = CourseEnrollment.get_enrollment(user, course_key)
     if not enrollment:
-        raise NotFound('No enrollment found for {}'.format(username))
+        raise NotFound('No enrollment found for user: `{}` on course_id `{}`'.format(username, course_id))
     try:
         enrollment.delete()
     except Exception:
-        raise NotFound('Error: Enrollment could not be deleted for {}'.format(username))
+        raise NotFound('Error: Enrollment could not be deleted for user: `{}` on course_id `{}`'.format(username, course_id))
 
 
 def enroll_on_course(course_id, *args, **kwargs):

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -19,6 +19,7 @@ from course_modes.models import CourseMode
 from enrollment import api
 from enrollment.errors import (CourseEnrollmentExistsError,
                                CourseModeNotFoundError)
+from eox_core.edxapp_wrapper.users import get_edxapp_user
 from eox_core.edxapp_wrapper.backends.edxfuture_i_v1 import get_program
 from eox_core.edxapp_wrapper.users import check_edxapp_account_conflicts
 from openedx.core.djangoapps.content.course_overviews.models import \
@@ -108,18 +109,6 @@ def get_enrollment(*args, **kwargs):
     errors = []
     course_id = kwargs.pop('course_id', None)
     username = kwargs.get('username', None)
-    email = kwargs.get('email', None)
-    try:
-        if username:
-            user = User.objects.get(username=username)
-        else:
-            user = User.objects.get(email=email)
-    except User.DoesNotExist: # pylint: disable=no-member
-        errors.append('No user found by {query} .'.format(query=str(kwargs)))
-        return None, errors
-
-    username = user.username
-    email = user.email
 
     try:
         LOG.info('Getting enrollment information of student: %s  course: %s', username, course_id)

--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -134,6 +134,8 @@ def get_edxapp_user(**kwargs):
     """
     Retrieve an user by username and/or email
 
+    The user will be returned only if it belongs to the calling site
+
     Examples:
         >>> get_edxapp_user(
             {

--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -133,19 +133,37 @@ def create_edxapp_user(*args, **kwargs):
 def get_edxapp_user(**kwargs):
     """
     Retrieve an user by username and/or email
+
+    Examples:
+        >>> get_edxapp_user(
+            {
+                "username": "Bob",
+                "site": request.site
+            }
+        )
+        >>> get_edxapp_user(
+            {
+                "email": "Bob@mailserver.com",
+                "site": request.site
+            }
+        )
     """
     params = {key: kwargs.get(key) for key in ['username', 'email'] if key in kwargs}
     site = kwargs.get('site')
+    try:
+        domain = site.domain
+    except AttributeError:
+        domain = None
 
     try:
         user = User.objects.get(**params)
         for source_method in FetchUserSiteSources.get_enabled_source_methods():
-            if source_method(user, site.domain):
+            if source_method(user, domain):
                 break
         else:
             raise User.DoesNotExist
     except User.DoesNotExist:
-        raise APIException('No user found by {query} on site {site}.'.format(query=str(params), site=site.domain))
+        raise APIException('No user found by {query} on site {site}.'.format(query=str(params), site=domain))
     return user
 
 
@@ -168,23 +186,26 @@ class FetchUserSiteSources(object):
     get_enabled_source_methods that just brings an array of functions enabled to do so
     """
 
-    ALL_SOURCES = ['fetch_from_created_on_site_prop', 'fetch_from_user_signup_source']
-
     @classmethod
     def get_enabled_source_methods(cls):
         """ brings the array of methods to check if an user belongs to a site """
-        sources = getattr(settings, 'EOX_CORE_USER_ORIGIN_SITE_SOURCES', cls.ALL_SOURCES)
+        sources = getattr(settings, 'EOX_CORE_USER_ORIGIN_SITE_SOURCES')
         return [getattr(cls, source) for source in sources]
 
     @staticmethod
-    def fetch_from_created_on_site_prop(user, site):
+    def fetch_from_created_on_site_prop(user, domain):
         """ fetch option """
-        return UserAttribute.get_user_attribute(user, 'created_on_site') == site
+        return UserAttribute.get_user_attribute(user, 'created_on_site') == domain
 
     @staticmethod
-    def fetch_from_user_signup_source(user, site):
+    def fetch_from_user_signup_source(user, domain):
         """ fetch option """
-        return len(UserSignupSource.objects.filter(user=user, site=site)) > 0
+        return len(UserSignupSource.objects.filter(user=user, site=domain)) > 0
+
+    @staticmethod
+    def fetch_from_unfiltered_table(user, site):
+        """ fetch option that does not take into account the multi-tentancy model of the installation """
+        return bool(user)
 
 
 def get_course_enrollment():

--- a/eox_core/settings/aws.py
+++ b/eox_core/settings/aws.py
@@ -63,12 +63,12 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY
     )
     if not settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
-        local_eox_core_user_origin_sources = [
+        user_origin_sources = [
             'fetch_from_unfiltered_table',
         ]
     else:
-        local_eox_core_user_origin_sources = settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES
+        user_origin_sources = settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES
     settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = getattr(settings, 'ENV_TOKENS', {}).get(
         'EOX_CORE_USER_ORIGIN_SITE_SOURCES',
-        local_eox_core_user_origin_sources
+        user_origin_sources
     )

--- a/eox_core/settings/aws.py
+++ b/eox_core/settings/aws.py
@@ -57,3 +57,18 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT',
         settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT
     )
+
+    settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_USER_ENABLE_MULTI_TENANCY',
+        settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY
+    )
+    if not settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
+        local_eox_core_user_origin_sources = [
+            'fetch_from_unfiltered_table',
+        ]
+    else:
+        local_eox_core_user_origin_sources = settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES
+    settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_USER_ORIGIN_SITE_SOURCES',
+        local_eox_core_user_origin_sources
+    )

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -31,3 +31,11 @@ def plugin_settings(settings):
     settings.EOX_CORE_COURSES_BACKEND = "eox_core.edxapp_wrapper.backends.courses_h_v1"
     settings.EOX_CORE_SITE_CONFIGURATION = "eox_core.edxapp_wrapper.backends.site_configuration_h_v1"
     settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT = 1000
+    settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = True
+    settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = ['fetch_from_unfiltered_table',]
+
+    if settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
+        settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = [
+            'fetch_from_created_on_site_prop',
+            'fetch_from_user_signup_source',
+        ]


### PR DESCRIPTION
###  Fix CRUD operations in enrollment API

### **Description**

The purpose of this PR is to fix/patch:

- [x] Get enrollment: Serializer asks for unnecessary fields
- [x] Put and update: Fill missing serializer fields

in Enrollment API

### **Testing**
_UPDATE ENROLLMENT_
```shell	 
curl -X PUT --header "Authorization: Bearer <AUTH_TOKEN> " -H "Accept: application/json" \
	http://edx.devstack.lms:18000/eox-core/api/v1/enrollment/ --header "Content-Type: application/json" \
	--data '{"course_id": "course-v1:edX+DemoX+Demo_Course", "email": "username@example.com",
	"mode": "audit", "is_active": "False", "enrollment_attributes": [{"namespace": "credit", "name": "provider_id", "value": "hogwarts" }]
}'
```

_GET ENROLLMENT_
```shell	 
curl -X GET --header "Authorization: Bearer <AUTH_TOKEN> " -H "Accept: application/json" \
	http://edx.devstack.lms:18000/eox-core/api/v1/enrollment/ --header "Content-Type: application/json" \
	--data '{"course_id": "course-v1:edX+DemoX+Demo_Course", "email": "username@example.com"
}'
```

_DELETE ENROLLMENT_
```shell
curl -X DELETE --header "Authorization: Bearer <AUTH_TOKEN> " -H "Accept: application/json" \
	http://edx.devstack.lms:18000/eox-core/api/v1/enrollment/ --header "Content-Type: application/json" \
	--data '{"course_id": "course-v1:edX+DemoX+Demo_Course", "email": "username@example.com"
}'
```

### **Reviewers**

- [ ] @felipemontoya 

- [ ] @diegomillan 