### PR TITLE
Guarantee the limit at the current coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             make python-quality-test
             make javascript-quality-test
             coverage run --source="." -m pytest ./eox_core
-            coverage report --fail-under=40
+            coverage report --fail-under=60
 
       - store_artifacts:
           path: test-reports
@@ -108,7 +108,7 @@ jobs:
             make python-quality-test
             make javascript-quality-test
             coverage run --source="." -m pytest ./eox_core
-            coverage report --fail-under=40 --rcfile=.coveragerc
+            coverage report --fail-under=60 --rcfile=.coveragerc
 
       - store_artifacts:
           path: test-reports


### PR DESCRIPTION
This PR simply raises the minimum limit for coverage to 60% excluding the backends