### PR TITLE
Add missing email field to EnrollmentQuerySerializer

### DIFF
--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -84,10 +84,11 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
 
 class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     """
-    Handles the serialization of the context data required to create an enrollemnt
+    Handles the serialization of the context data required to create an enrollment
     on different backends
     """
     username = serializers.CharField(max_length=30, default=None)
+    email = serializers.CharField(max_length=255, default=None)
     force = serializers.BooleanField(default=False)
     bundle_id = serializers.CharField(max_length=255, default=None)
 


### PR DESCRIPTION
###  Add missing email field to EnrollmentQuerySerializer

### **Description**

The purpose of this PR is to patch the missing email field of EnrollmentQuerySerializer:

- [x]  Add missing email field 
- [x]  Add test to ensure email is not erased again.

### **Reviewers**

- [x] @felipemontoya 