### PR TITLE
More standard methods por POST & PUT

### DIFF
--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -118,7 +118,7 @@ class TestEnrollmentsAPI(TestCase):
             'is_active': True,
         }
 
-        m_update_enrollment.return_value = enrollments_response, [None]
+        m_update_enrollment.return_value = enrollments_response
         params = [{
             'mode': 'audit',
             'username': 'test',

--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -83,6 +83,7 @@ class TestEnrollmentsAPI(TestCase):
 
     @patch_permissions
     @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
+    @patch('eox_core.api.v1.views.get_edxapp_user')
     @patch('eox_core.api.v1.views.create_enrollment')
     def test_api_post_works(self, m_create_enrollment, *_):
         """ Test that the POST method works in normal conditions """

--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -68,7 +68,7 @@ class TestEnrollmentsAPI(TestCase):
         params = {
             'mode': 'audit',
         }
-        response = self.client.post('/api/v1/enrollment/', params)
+        response = self.client.post('/api/v1/enrollment/', data=params)
         self.assertEqual(response.status_code, 400)
         self.assertIn('non_field_errors', response.data)
 
@@ -77,7 +77,7 @@ class TestEnrollmentsAPI(TestCase):
             'mode': 'audit',
             'username': 'test',
         }
-        response = self.client.post('/api/v1/enrollment/', params)
+        response = self.client.post('/api/v1/enrollment/', data=params)
         self.assertEqual(response.status_code, 400)
         self.assertIn('non_field_errors', response.data)
 
@@ -99,34 +99,37 @@ class TestEnrollmentsAPI(TestCase):
             'username': 'test',
             'course_id': 'course-v1:org+course+run',
         }
-        response = self.client.post('/api/v1/enrollment/', params)
+        response = self.client.post('/api/v1/enrollment/', data=params)
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(params, response.data)
 
     @patch_permissions
     @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
+    @patch('eox_core.api.v1.views.get_edxapp_user')
     @patch('eox_core.api.v1.views.update_enrollment')
-    def test_api_put_works(self, m_update_enrollment, *_):
-        """ Test that the PUT method works in normal conditions with a bundle """
+    def test_api_put_works(self, m_update_enrollment, m_get_user, *_):
+        """ Test that the PUT method works in normal conditions with a list of enrollments """
 
-        enrollments_for_bundle = [{
+        enrollments_response = {
             'mode': 'audit',
             'user': 'test',  # this is the source value for the username field in the serializer
             'course_id': 'course-v1:org+course+run',
             'is_active': True,
-        }, {
-            'mode': 'audit',
-            'user': 'test',
-            'course_id': 'course-v1:org+course_2+run',
-            'is_active': True,
-        }]
-        m_update_enrollment.return_value = enrollments_for_bundle, [None, None]
-        params = {
+        }
+
+        m_update_enrollment.return_value = enrollments_response, [None]
+        params = [{
             'mode': 'audit',
             'username': 'test',
-            'bundle_id': '3019bf08-eb47-4541-9d84-d20c25ed8f7f',  # random uuid
-        }
-        response = self.client.put('/api/v1/enrollment/', params)
+            'course_id': 'course-v1:org+course+run',
+        }, {
+            'mode': 'audit',
+            'username': 'test',
+            'course_id': 'course-v1:org+course_2+run',
+        }]
+
+        response = self.client.put('/api/v1/enrollment/', data=params, format='json')
+        m_get_user.assert_called()
         self.assertEqual(response.status_code, 200)
         self.assertIn('course_id', response.data[0])
         self.assertIn('is_active', response.data[0])
@@ -146,26 +149,3 @@ class TestEnrollmentsAPI(TestCase):
         m_get_user.assert_called_once_with(username='test')
         m_delete_enrollment.assert_called_once_with(course_id='course-v1:org+course+run', user=m_get_user.return_value)
         self.assertEqual(response.status_code, 204)
-
-    @patch_permissions
-    @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid')
-    @patch('eox_core.api.v1.views.create_enrollment')
-    def test_api_post_works_with_email(self, m_create_enrollment, m_check_enrollment, *_):
-        """ Test that the POST method works using only email as a reference of the user """
-
-        m_enrollment = {
-            'mode': 'audit',
-            'user': 'test',  # this is the source value for the username field in the serializer
-            'course_id': 'course-v1:org+course+run',
-            'is_active': True,
-        }
-        m_check_enrollment.return_value = []
-        m_create_enrollment.return_value = m_enrollment, None
-        params = {
-            'mode': 'audit',
-            'email': 'test@example.com',
-            'course_id': 'course-v1:org+course+run',
-        }
-        response = self.client.post('/api/v1/enrollment/', params)
-        m_check_enrollment.assert_called_once_with(email='test@example.com', bundle_id=None, course_id='course-v1:org+course+run', enrollment_attributes=[], force=False, is_active=True, mode=u'audit', username=None)
-        self.assertEqual(response.status_code, 200)

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -116,7 +116,7 @@ class EdxappEnrollment(APIView):
 
         course_id = kwargs.pop('course_id', None)
         if not course_id:
-            raise ValidationError(detail='You have to provide a course_id')
+            raise ValidationError(detail='You have to provide a course_id for updates')
         mode = kwargs.pop('mode', None)
 
         return update_enrollment(user, course_id, mode, **kwargs)
@@ -219,6 +219,7 @@ class EdxappEnrollment(APIView):
         Returns: List of responses
         """
         multiple_responses = []
+        errors_in_bulk_response = False
         many = isinstance(request_data, list)
         serializer = EdxappCourseEnrollmentQuerySerializer(data=request_data, many=many)
         serializer.is_valid(raise_exception=True)
@@ -227,21 +228,36 @@ class EdxappEnrollment(APIView):
             data = [data]
 
         for enrollment_query in data:
-            enrollments, msgs = action_method(**enrollment_query)
-            if not isinstance(enrollments, list):
-                enrollments = [enrollments]
-                msgs = [msgs]
-            for enrollment, msg in zip(enrollments, msgs):
-                response_data = EdxappCourseEnrollmentSerializer(enrollment).data
-                if msg:
-                    response_data["messages"] = msg
-                multiple_responses.append(response_data)
+
+            try:
+                enrollments, msgs = action_method(**enrollment_query)
+                # This logic block is needed to convert a single bundle_id enrollment in a list
+                # of course_id enrollments which are appended to the response individually
+                if not isinstance(enrollments, list):
+                    enrollments = [enrollments]
+                    msgs = [msgs]
+                for enrollment, msg in zip(enrollments, msgs):
+                    response_data = EdxappCourseEnrollmentSerializer(enrollment).data
+                    if msg:
+                        response_data["messages"] = msg
+                    multiple_responses.append(response_data)
+
+            except APIException as error:
+                errors_in_bulk_response = True
+                enrollment_query["error"] = {
+                    "detail": error.detail,
+                }
+                multiple_responses.append(enrollment_query)
 
         if many or 'bundle_id' in request_data:
             response = multiple_responses
         else:
             response = multiple_responses[0]
-        return Response(response)
+
+        response_status = status.HTTP_200_OK
+        if errors_in_bulk_response:
+            response_status = status.HTTP_202_ACCEPTED
+        return Response(response, status=response_status)
 
     def handle_exception(self, exc):
         """

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -115,7 +115,7 @@ class EdxappEnrollment(APIView):
 
     def post(self, request, *args, **kwargs):
         """
-        Creates the users on edxapp
+        Handle creation of single or bulk enrollments
         """
         data = request.data
         return EdxappEnrollment.prepare_multiresponse(data, self.single_enrollment_create)

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -91,12 +91,21 @@ class EdxappEnrollment(APIView):
         self.query_params = None
         self.site = None
 
+    def single_enrollment_create(self, *args, **kwargs):
+        """
+        Handle one create at the time
+        """
+        user_query = self.get_user_query(None, query_params=kwargs)
+        user = get_edxapp_user(**user_query)
+
+        return create_enrollment(user, **kwargs)
+
     def post(self, request, *args, **kwargs):
         """
         Creates the users on edxapp
         """
         data = request.data
-        return EdxappEnrollment.prepare_multiresponse(data, create_enrollment)
+        return EdxappEnrollment.prepare_multiresponse(data, self.single_enrollment_create)
 
     def single_enrollment_update(self, *args, **kwargs):
         """

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -207,7 +207,7 @@ def _enroll_on_course(user, course_id, *args, **kwargs):
             LOG.info('Force create enrollment %s, %s, %s', username, course_id, mode)
             enrollment = _force_create_enrollment(username, course_id, mode, is_active)
         else:
-            raise APIException(repr(err))
+            raise APIException(err.message)
 
     if enrollment_attributes is not None:
         api.set_enrollment_attributes(username, course_id, enrollment_attributes)
@@ -278,6 +278,8 @@ def check_edxapp_enrollment_is_valid(*args, **kwargs):
 
     if program_uuid and course_id:
         return ['You have to provide a course_id or bundle_id but not both']
+    if not program_uuid and not course_id:
+        return ['You have to provide a course_id or bundle_id']
     if not email and not username:
         return ['Email or username needed']
     if not check_edxapp_account_conflicts(email=email, username=username):

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -57,6 +57,7 @@ def create_enrollment(user, *args, **kwargs):
 
     raise APIException("You have to provide a course_id or bundle_id")
 
+
 def update_enrollment(user, course_id, mode, *args, **kwargs):
     """
     Update enrollment of given user in the course provided.
@@ -222,7 +223,7 @@ def _enroll_on_course(user, course_id, *args, **kwargs):
 
 def _enroll_on_program(user, program_uuid, *arg, **kwargs):
     """
-    enroll user on each of the courses of a progam
+    enroll user on each of the courses of a program
     """
     results = []
     errors = []


### PR DESCRIPTION
This PR refactors a bit the logic for POST and PUT to:
- make the underlying functions require a user as a parameter, removing the need for 3 different implementations of get_edxapp_user
- have a function to update/create 1 single record in the view, where the required user param is explicitly passed to the underlying function
- support the capacity to respond in bulk to the bulk responses when one or more end in errors 