### PR TITLE
Course id validation

### DIFF
--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 from rest_framework import serializers
 from eox_core.edxapp_wrapper.users import check_edxapp_account_conflicts, get_user_read_only_serializer
 from eox_core.edxapp_wrapper.enrollments import check_edxapp_enrollment_is_valid
+from eox_core.edxapp_wrapper.coursekey import validate_org, get_valid_course_key
 
 
 class EdxappUserSerializer(serializers.Serializer):
@@ -57,6 +58,22 @@ class EdxappEnrollmentAttributeSerializer(serializers.Serializer):
     name = serializers.CharField()
     value = serializers.CharField()
 
+class EdxappCourseKeyField(serializers.Field):
+    """
+    CourseKey Field
+    """
+    def to_representation(self, value):
+        return str(value)
+
+    def to_internal_value(self, data):
+        """
+        Check course_id has the correct format and that it is allowed inside the org
+        """
+        if validate_org(data):
+            return str(get_valid_course_key(data))
+        else:
+            raise serializers.ValidationError('Course_id not allowed for given organization')
+
 
 class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     """Serializes CourseEnrollment
@@ -70,7 +87,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
-    course_id = serializers.CharField(max_length=255, default=None)
+    course_id = EdxappCourseKeyField()
 
     def validate(self, attrs):
         """
@@ -90,6 +107,7 @@ class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     username = serializers.CharField(max_length=30, default=None)
     email = serializers.CharField(max_length=255, default=None)
     force = serializers.BooleanField(default=False)
+    course_id = EdxappCourseKeyField(default=None)
     bundle_id = serializers.CharField(max_length=255, default=None)
 
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -58,6 +58,7 @@ class EdxappEnrollmentAttributeSerializer(serializers.Serializer):
     name = serializers.CharField()
     value = serializers.CharField()
 
+
 class EdxappCourseKeyField(serializers.Field):
     """
     CourseKey Field

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -59,7 +59,7 @@ class EdxappEnrollmentAttributeSerializer(serializers.Serializer):
     value = serializers.CharField()
 
 
-class EdxappCourseKeyField(serializers.Field):
+class EdxappValidatedCourseIDField(serializers.Field):
     """
     CourseKey Field
     """
@@ -88,7 +88,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
-    course_id = EdxappCourseKeyField()
+    course_id = EdxappValidatedCourseIDField()
 
     def validate(self, attrs):
         """
@@ -108,7 +108,7 @@ class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     username = serializers.CharField(max_length=30, default=None)
     email = serializers.CharField(max_length=255, default=None)
     force = serializers.BooleanField(default=False)
-    course_id = EdxappCourseKeyField(default=None)
+    course_id = EdxappValidatedCourseIDField(default=None)
     bundle_id = serializers.CharField(max_length=255, default=None)
 
 

--- a/eox_core/api/v1/tests/test_coursekey.py
+++ b/eox_core/api/v1/tests/test_coursekey.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from rest_framework.serializers import ValidationError
 from ..serializers import EdxappCourseEnrollmentSerializer
 
+
 class TestCourseKeyValidation(TestCase):
     """ Tests for the CourseKey validations """
 
@@ -23,10 +24,10 @@ class TestCourseKeyValidation(TestCase):
             'is_active': True,
         }
 
-
-    @patch('eox_core.api.v1.serializers.get_valid_course_key')
+    @patch('eox_core.api.v1.serializers.validate_org')
     @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
-    def test_incorrect_course_id(self, _, m_get_valid_course_key):
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
+    def test_incorrect_course_id(self, m_get_valid_course_key, *_):
         """ Test that the CourseKey validation fails due to invalid formatting """
         course_id = "test1234"
         m_get_valid_course_key.side_effect = ValidationError("No valid course_id {}".format(course_id))
@@ -35,7 +36,6 @@ class TestCourseKeyValidation(TestCase):
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
         m_get_valid_course_key.assert_called_once_with(course_id)
-
 
     @patch('eox_core.api.v1.serializers.validate_org')
     @patch('eox_core.api.v1.serializers.get_valid_course_key')

--- a/eox_core/api/v1/tests/test_coursekey.py
+++ b/eox_core/api/v1/tests/test_coursekey.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Test module for CourseKey validations under the open-release/hawthorn.beta1 tag
+"""
+from mock import patch
+from django.test import TestCase
+from rest_framework.serializers import ValidationError
+from ..serializers import EdxappCourseEnrollmentSerializer
+
+class TestCourseKeyValidation(TestCase):
+    """ Tests for the CourseKey validations """
+
+    patch_permissions = patch('eox_core.api.v1.permissions.EoxCoreAPIPermission.has_permission', return_value=True)
+
+    def setUp(self):
+        """ setup """
+        super(TestCourseKeyValidation, self).setUp()
+        self.enrollment_serializer = EdxappCourseEnrollmentSerializer
+        self.m_enrollment = {
+            'mode': 'audit',
+            'user': 'test',
+            'is_active': True,
+        }
+
+
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
+    @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
+    def test_incorrect_course_id(self, _, m_get_valid_course_key):
+        """ Test that the CourseKey validation fails due to invalid formatting """
+        course_id = "test1234"
+        m_get_valid_course_key.side_effect = ValidationError("No valid course_id {}".format(course_id))
+        self.m_enrollment['course_id'] = course_id
+        serializer = self.enrollment_serializer(data=self.m_enrollment)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+        m_get_valid_course_key.assert_called_once_with(course_id)
+
+
+    @patch('eox_core.api.v1.serializers.validate_org')
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
+    @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
+    def test_course_id_valid_org(self, _, m_get_valid_course_key, m_validate_org):
+        """ Test that the CourseKey validation fails because it doesn't belong to the filtered org """
+        course_id = "course-v1:org+course+run"
+        m_get_valid_course_key.return_value = None
+        m_validate_org.return_value = False
+
+        self.m_enrollment['course_id'] = course_id
+        serializer = self.enrollment_serializer(data=self.m_enrollment)
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+        m_validate_org.assert_called_once_with(course_id)
+
+    @patch('eox_core.api.v1.serializers.validate_org')
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
+    @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
+    def test_course_id_correct(self, _, m_get_valid_course_key, m_validate_org):
+        """ Test that the CourseKey validation works under normal conditions """
+        course_id = "course-v1:org+course+run"
+        m_get_valid_course_key.return_value = None
+        m_validate_org.return_value = True
+
+        self.m_enrollment['course_id'] = course_id
+        serializer = self.enrollment_serializer(data=self.m_enrollment)
+
+        serializer.is_valid(raise_exception=True)
+
+        m_validate_org.assert_called_once_with(course_id)
+        m_get_valid_course_key.assert_called_once_with(course_id)

--- a/eox_core/api/v1/tests/test_coursekey.py
+++ b/eox_core/api/v1/tests/test_coursekey.py
@@ -9,14 +9,12 @@ from rest_framework.serializers import ValidationError
 from ..serializers import EdxappCourseEnrollmentSerializer
 
 
-class TestCourseKeyValidation(TestCase):
+class CourseKeyValidationTest(TestCase):
     """ Tests for the CourseKey validations """
-
-    patch_permissions = patch('eox_core.api.v1.permissions.EoxCoreAPIPermission.has_permission', return_value=True)
 
     def setUp(self):
         """ setup """
-        super(TestCourseKeyValidation, self).setUp()
+        super(CourseKeyValidationTest, self).setUp()
         self.enrollment_serializer = EdxappCourseEnrollmentSerializer
         self.m_enrollment = {
             'mode': 'audit',

--- a/eox_core/api/v1/tests/test_enrollments.py
+++ b/eox_core/api/v1/tests/test_enrollments.py
@@ -82,6 +82,8 @@ class TestEnrollmentsAPI(TestCase):
         self.assertIn('non_field_errors', response.data)
 
     @patch_permissions
+    @patch('eox_core.api.v1.serializers.validate_org')
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
     @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
     @patch('eox_core.api.v1.views.get_edxapp_user')
     @patch('eox_core.api.v1.views.create_enrollment')
@@ -105,6 +107,8 @@ class TestEnrollmentsAPI(TestCase):
         self.assertDictContainsSubset(params, response.data)
 
     @patch_permissions
+    @patch('eox_core.api.v1.serializers.validate_org')
+    @patch('eox_core.api.v1.serializers.get_valid_course_key')
     @patch('eox_core.api.v1.serializers.check_edxapp_enrollment_is_valid', return_value=[])
     @patch('eox_core.api.v1.views.get_edxapp_user')
     @patch('eox_core.api.v1.views.update_enrollment')

--- a/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
@@ -38,7 +38,7 @@ def validate_org(course_id):
     if not settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
         return True
 
-    course_key = CourseKey.from_string(course_id)
+    course_key = get_valid_course_key(course_id)
     current_site_orgs = get_current_site_orgs() or []
 
     if not current_site_orgs:

--- a/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Backend for the CourseKey validations that works under the open-release/hawthorn.beta1 tag
+"""
+# pylint: disable=import-error, protected-access
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys import InvalidKeyError
+from rest_framework.serializers import ValidationError
+
+from openedx.core.djangoapps.site_configuration.helpers import (
+    get_all_orgs,
+    get_current_site_orgs,
+)
+
+def get_valid_course_key(course_id):
+    """
+    Return the CourseKey if the course_id is valid
+    """
+    try:
+        return CourseKey.from_string(course_id)
+    except InvalidKeyError:
+        raise ValidationError("No valid course_id {}".format(course_id))
+
+def validate_org(course_id):
+    """
+    Validate the course organization against all possible orgs for the site
+
+    To determine if the Org is valid we must look at 3 things
+    1 Orgs in the current site
+    2 Orgs in other sites
+    3 flag EOX_CORE_USER_ENABLE_MULTI_TENANCY
+    """
+
+    if not settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
+        return True
+
+    course_key = CourseKey.from_string(course_id)
+    current_site_orgs = get_current_site_orgs() or []
+
+    if not current_site_orgs:
+        if course_key.org in get_all_orgs():
+            return False
+        return True
+    else:
+        return course_key.org in current_site_orgs

--- a/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
@@ -16,6 +16,7 @@ from openedx.core.djangoapps.site_configuration.helpers import (
     get_current_site_orgs,
 )
 
+
 def get_valid_course_key(course_id):
     """
     Return the CourseKey if the course_id is valid
@@ -24,6 +25,7 @@ def get_valid_course_key(course_id):
         return CourseKey.from_string(course_id)
     except InvalidKeyError:
         raise ValidationError("No valid course_id {}".format(course_id))
+
 
 def validate_org(course_id):
     """

--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -297,6 +297,9 @@ def check_edxapp_enrollment_is_valid(*args, **kwargs):
         return ['User not found']
     if mode not in CourseMode.ALL_MODES:
         return ['Invalid mode given:' + mode]
+    if course_id:
+        if not validate_org(course_id):
+            errors.append('Enrollment not allowed for given org')
     if course_id and not force:
         try:
             api.validate_course_mode(course_id, mode, is_active=is_active)

--- a/eox_core/edxapp_wrapper/coursekey.py
+++ b/eox_core/edxapp_wrapper/coursekey.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+CourseKey public function definitions
+"""
+
+from importlib import import_module
+from django.conf import settings
+
+
+def get_valid_course_key(course_id):
+    """
+    Return a valid CourseKey for the given course_id
+    """
+
+    backend_function = settings.EOX_CORE_COURSEKEY_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_valid_course_key(course_id)
+
+def validate_org(course_id):
+    """
+    Return a valid CourseKey for the given course_id
+    """
+
+    backend_function = settings.EOX_CORE_COURSEKEY_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.validate_org(course_id)

--- a/eox_core/edxapp_wrapper/coursekey.py
+++ b/eox_core/edxapp_wrapper/coursekey.py
@@ -18,6 +18,7 @@ def get_valid_course_key(course_id):
 
     return backend.get_valid_course_key(course_id)
 
+
 def validate_org(course_id):
     """
     Return a valid CourseKey for the given course_id

--- a/eox_core/edxapp_wrapper/tests/test_coursekey.py
+++ b/eox_core/edxapp_wrapper/tests/test_coursekey.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Test module for CourseKey under the open-release/hawthorn.beta1 tag
+"""
+from __future__ import absolute_import, unicode_literals
+
+import mock
+
+from django.conf import settings
+from django.test import TestCase
+from ..coursekey import (
+    validate_org,
+    get_valid_course_key,
+)
+
+
+class CourseKeyTest(TestCase):
+    """ Tests correct load of CourseKey module """
+
+    def setUp(self):
+        """ setup """
+        super(CourseKeyTest, self).setUp()
+        self.m_course_id = "course-v1:org+course+run"
+
+    @mock.patch('eox_core.edxapp_wrapper.coursekey.import_module')
+    def test_import_the_backend(self, m_import):
+        """ Test we import the correct backend defined in the settings """
+
+        validate_org(self.m_course_id)
+        m_import.assert_called_with(settings.EOX_CORE_COURSEKEY_BACKEND)
+
+    @mock.patch('eox_core.edxapp_wrapper.coursekey.import_module')
+    def test_call_the_backend(self, m_import):
+        """ Test we use the imported backend """
+        m_coursekey_backend = mock.MagicMock()
+        m_import.return_value = m_coursekey_backend
+
+        validate_org(self.m_course_id)
+        m_coursekey_backend.validate_org.assert_called_with(self.m_course_id)
+
+        get_valid_course_key(self.m_course_id)
+        m_coursekey_backend.get_valid_course_key.assert_called_with(self.m_course_id)

--- a/eox_core/settings/aws.py
+++ b/eox_core/settings/aws.py
@@ -49,6 +49,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_CORE_COURSES_BACKEND',
         settings.EOX_CORE_COURSES_BACKEND
     )
+    settings.EOX_CORE_COURSEKEY_BACKEND = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_COURSEKEY_BACKEND',
+        settings.EOX_CORE_COURSEKEY_BACKEND
+    )
     settings.EOX_CORE_SITE_CONFIGURATION = getattr(settings, 'ENV_TOKENS', {}).get(
         'EOX_CORE_SITE_CONFIGURATION',
         settings.EOX_CORE_SITE_CONFIGURATION

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -29,6 +29,7 @@ def plugin_settings(settings):
     settings.DATA_API_MAX_PAGE_SIZE = 5000
     settings.EDXMAKO_MODULE = "eox_core.edxapp_wrapper.backends.edxmako_module"
     settings.EOX_CORE_COURSES_BACKEND = "eox_core.edxapp_wrapper.backends.courses_h_v1"
+    settings.EOX_CORE_COURSEKEY_BACKEND = "eox_core.edxapp_wrapper.backends.coursekey_h_v1"
     settings.EOX_CORE_SITE_CONFIGURATION = "eox_core.edxapp_wrapper.backends.site_configuration_h_v1"
     settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT = 1000
     settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = True

--- a/eox_core/settings/test.py
+++ b/eox_core/settings/test.py
@@ -19,6 +19,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     """
     settings.EOX_CORE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.users_h_v1_test"
     settings.EOX_CORE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.enrollment_h_v1"
+    settings.EOX_CORE_COURSEKEY_BACKEND = "eox_core.edxapp_wrapper.backends.coursekey_h_v1"
     settings.EOX_CORE_CERTIFICATES_BACKEND = "eox_core.edxapp_wrapper.backends.certificates_h_v1_test"
     settings.EOX_CORE_COURSEWARE_BACKEND = "eox_core.edxapp_wrapper.backends.courseware_h_v1"
     settings.EOX_CORE_GRADES_BACKEND = "eox_core.edxapp_wrapper.backends.grades_h_v1"


### PR DESCRIPTION
###  Course id validations

### **Description**

The purpose of this PR is to add the Course id validations when performing serializations to clean up redundant validations across views:

- [x] Create CourseKeyField: This field will contain the course_id.
- [x] Extract course_id validations such as validate_org and get_course_key to CourseKey backend.
- [x] Use CourseKeyField in the EdxappSerializers.

### **Reviewers**

- [x] @felipemontoya 

- [x] @diegomillan 