### PR TITLE
Making the errors of the CourseEnrollments be a lot more useful.

### DIFF
--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -209,13 +209,17 @@ def _enroll_on_course(user, course_id, *args, **kwargs):
             LOG.info('Force create enrollment %s, %s, %s', username, course_id, mode)
             enrollment = _force_create_enrollment(username, course_id, mode, is_active)
         else:
+            if not str(err):
+                err = err.__class__.__name__
             raise APIException(detail=err)
 
     if enrollment_attributes is not None:
         api.set_enrollment_attributes(username, course_id, enrollment_attributes)
-
-    enrollment['enrollment_attributes'] = enrollment_attributes
-    enrollment['course_id'] = course_id
+    try:
+        enrollment['enrollment_attributes'] = enrollment_attributes
+        enrollment['course_id'] = course_id
+    except TypeError:
+        pass
     return enrollment, errors
 
 


### PR DESCRIPTION
This PR changes the response of the enrollments API. If there is no message to show, we return the name of the class instead. This alone will give us a lot of information at the API consumer.

Also we now don't fail when the enrollment_attribute assignment fails for the response.

This PR solves an edge case that we found on the ticket #7568.