### PR TITLE
Adding pipeline function to make sure users have a profile model

### DIFF
--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -29,7 +29,7 @@ from student.helpers import (  # pylint: disable=import-error
 from student.helpers import do_create_account  # pylint: disable=import-error
 from student.models import CourseEnrollment  # pylint: disable=import-error
 from student.models import (LoginFailures, UserAttribute, UserSignupSource,  # pylint: disable=import-error
-                            create_comments_service_user)
+                            UserProfile, create_comments_service_user)
 
 LOG = logging.getLogger(__name__)
 User = get_user_model()  # pylint: disable=invalid-name
@@ -225,3 +225,9 @@ def get_user_signup_source():
 def get_login_failures():
     """ get LoginFailures model """
     return LoginFailures
+
+
+def get_user_profile():
+    """ Gets the UserProfile model """
+
+    return UserProfile

--- a/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
@@ -82,3 +82,12 @@ def get_login_failures():
     except ImportError:
         LoginFailures = object
     return LoginFailures
+
+
+def get_user_profile():
+    """ Gets the UserProfile model """
+    try:
+        from student.models import UserProfile
+    except ImportError:
+        UserProfile = object
+    return UserProfile

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -78,3 +78,12 @@ def get_login_failures():
     backend = import_module(backend_function)
 
     return backend.get_login_failures()
+
+
+def get_user_profile():
+    """ Gets the UserProfile model """
+
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_user_profile()

--- a/eox_core/pipeline.py
+++ b/eox_core/pipeline.py
@@ -1,0 +1,22 @@
+"""
+The pipeline module defines functions that are used in the third party authentication flow
+"""
+import logging
+from eox_core.edxapp_wrapper.users import get_user_profile
+
+LOG = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument,keyword-arg-before-vararg
+def ensure_user_has_profile(backend, details, user=None, *args, **kwargs):
+    """
+    This pipeline function creates an empty profile object if the user does not have one.
+    It can be used with the user_details_force_sync function to fill the profile after creation.
+    """
+    if user:
+        user_profile_model = get_user_profile()
+        try:
+            __ = user.profile
+        except user_profile_model.DoesNotExist:
+            user_profile_model.objects.create(user=user)
+            LOG.info('Created new profile for user during the third party pipeline: "%s"', user)

--- a/eox_core/tests/test_pipeline.py
+++ b/eox_core/tests/test_pipeline.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+"""
+Tests for the pipeline module used in third party auth.
+"""
+from django.test import TestCase
+from mock import MagicMock, patch, PropertyMock
+
+from eox_core.pipeline import ensure_user_has_profile
+
+
+class EnsureUserProfileTest(TestCase):
+    """
+    Test the custom association backend.
+    """
+    def setUp(self):
+        self.backend_mock = MagicMock()
+        self.user_mock = MagicMock()
+
+    @patch('eox_core.edxapp_wrapper.users.import_module')
+    def test_user_with_profile_works(self, import_mock):
+        """
+        A user that already has a profile will do nothing
+        """
+        backend = MagicMock()
+        import_mock.side_effect = backend
+
+        ensure_user_has_profile(self.backend_mock, {}, user=self.user_mock)
+        backend().get_user_profile().assert_not_called()
+
+    @patch('eox_core.edxapp_wrapper.users.import_module')
+    def test_user_without_profile_works(self, import_mock):
+        """
+        A user that has no profile will create one
+        """
+        backend = MagicMock()
+        import_mock.side_effect = backend
+        backend().get_user_profile().DoesNotExist = ValueError
+        type(self.user_mock).profile = PropertyMock(side_effect=ValueError)
+
+        ensure_user_has_profile(self.backend_mock, {}, user=self.user_mock)
+        backend().get_user_profile().objects.create.assert_called()


### PR DESCRIPTION
This PR adds a function to the plugin than can be called on the TPA_SAML_PIPELINE