### PR TITLE
Adding sentry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ $ source /path/to/venv/bin/activate
 (venv)$ pip-compile
 ```
 
+## Integrations with third party services
+
+The plugin offers some integrations listed below:
+
+1. **Sentry**: this service allows to track the errors generated on edx-platform. Check more details in https://sentry.io/welcome/. To enable the integration, follow the steps below:
+
+	* Install the plugin with Sentry support (extras_require [sentry])
+	* Sign up/in to your sentry account and create a new Django application integration.
+	* Get the DSN for your integration. This is an unique identifier for your application.
+	* Setup the following configuration values for edx-platform:
+
+		```yaml
+		EOX_CORE_SENTRY_INTEGRATION_DSN: <your DSN value>
+		```
+
+	By default, **EOX_CORE_SENTRY_INTEGRATION_DSN** setting is None, which disables the sentry integration.
+
 ## Course Management automation compilation
 
 We use webpack to bundle the React js application and its dependencies,

--- a/eox_core/settings/aws.py
+++ b/eox_core/settings/aws.py
@@ -3,6 +3,12 @@ Settings for eox_core project meant to be called on the edx-platform/*/envs/aws.
 """
 from .common import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+except ImportError:
+    sentry_sdk = DjangoIntegration = None
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """
@@ -107,3 +113,18 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
                 'eox_core.middleware.PathRedirectionMiddleware',
                 'eox_core.middleware.RedirectionsMiddleware'
             ]
+
+    # Sentry Integration
+    sentry_integration_dsn = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_SENTRY_INTEGRATION_DSN',
+        settings.EOX_CORE_SENTRY_INTEGRATION_DSN
+    )
+    if sentry_sdk is not None and sentry_integration_dsn is not None:
+        sentry_sdk.init(
+            dsn=sentry_integration_dsn,
+            integrations=[DjangoIntegration()],
+
+            # If you wish to associate users to errors (assuming you are using
+            # django.contrib.auth) you may enable sending PII data.
+            send_default_pii=True
+        )

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -46,3 +46,6 @@ def plugin_settings(settings):
             'fetch_from_created_on_site_prop',
             'fetch_from_user_signup_source',
         ]
+
+    # Sentry Integration
+    settings.EOX_CORE_SENTRY_INTEGRATION_DSN = None

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
     description="eduNEXT Openedx extensions",
     long_description="",
     install_requires=[],
+    extras_require={
+        "sentry": ["sentry-sdk==0.14.2"],
+    },
     scripts=[],
     license="AGPL",
     platforms=["any"],


### PR DESCRIPTION
This PR adds Sentry integration support through eox-core installation with extras_require option.

The plugin installation must be as fllows:
`pip install git+https://github.com/eduNEXT/eox-core.git@v2.7.0#egg=eox-core==2.7.0[sentry]`

This will install the sentry SDK to enable the configuration. The readme file was updated to include details on how to enable sentry integration.