### PR TITLE
Use 150 as username max length in Ironwood

### DIFF
--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -5,9 +5,15 @@ API v1 serializers.
 from __future__ import absolute_import, unicode_literals
 
 from rest_framework import serializers
-from eox_core.edxapp_wrapper.users import check_edxapp_account_conflicts, get_user_read_only_serializer
+from eox_core.edxapp_wrapper.users import (
+    check_edxapp_account_conflicts,
+    get_user_read_only_serializer,
+    get_username_max_length,
+)
 from eox_core.edxapp_wrapper.enrollments import check_edxapp_enrollment_is_valid
 from eox_core.edxapp_wrapper.coursekey import validate_org, get_valid_course_key
+
+USERNAME_MAX_LENGTH = get_username_max_length()
 
 
 class EdxappWithWarningSerializer(serializers.Serializer):
@@ -40,7 +46,7 @@ class EdxappUserSerializer(serializers.Serializer):
     """
 
     email = serializers.EmailField()
-    username = serializers.CharField(max_length=30)  # Can be updated to 150 after django 1.11 has settled in
+    username = serializers.CharField(max_length=USERNAME_MAX_LENGTH)
     password = serializers.CharField(
         style={'input_type': 'password'},
         write_only=True,
@@ -107,7 +113,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
 
     """
 
-    username = serializers.CharField(max_length=30, default=None, source='user')
+    username = serializers.CharField(max_length=USERNAME_MAX_LENGTH, default=None, source='user')
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
@@ -128,7 +134,7 @@ class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     Handles the serialization of the context data required to create an enrollment
     on different backends
     """
-    username = serializers.CharField(max_length=30, default=None)
+    username = serializers.CharField(max_length=USERNAME_MAX_LENGTH, default=None)
     email = serializers.CharField(max_length=255, default=None)
     force = serializers.BooleanField(default=False)
     course_id = EdxappValidatedCourseIDField(default=None)

--- a/eox_core/edxapp_wrapper/backends/users_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1.py
@@ -34,6 +34,7 @@ from student.models import (LoginFailures, UserAttribute, UserSignupSource,  # p
 
 LOG = logging.getLogger(__name__)
 User = get_user_model()  # pylint: disable=invalid-name
+USERNAME_MAX_LENGTH = 30
 
 
 def get_user_read_only_serializer():

--- a/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
@@ -4,6 +4,8 @@ Test backend to get CourseEnrollment Model.
 
 from django.contrib.auth.models import Permission
 
+USERNAME_MAX_LENGTH = 30
+
 
 def get_edxapp_user(**kwargs):
     """

--- a/eox_core/edxapp_wrapper/backends/users_i_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_i_v1.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Backend for the create_edxapp_user that works under the open-release/ironwood.master tag
+"""
+from __future__ import absolute_import, unicode_literals
+from eox_core.edxapp_wrapper.backends.users_h_v1 import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
+USERNAME_MAX_LENGTH = 150

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -87,3 +87,10 @@ def get_user_profile():
     backend = import_module(backend_function)
 
     return backend.get_user_profile()
+
+
+def get_username_max_length():
+    """ Gets max length allowed for the username"""
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+    return backend.USERNAME_MAX_LENGTH

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -19,7 +19,7 @@ def plugin_settings(settings):
     Defines eox-core settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    settings.EOX_CORE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.users_h_v1"
+    settings.EOX_CORE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.users_i_v1"
     settings.EOX_CORE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.enrollment_h_v1"
     settings.EOX_CORE_PRE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.pre_enrollment_h_v1"
     settings.EOX_CORE_CERTIFICATES_BACKEND = "eox_core.edxapp_wrapper.backends.certificates_h_v1"


### PR DESCRIPTION
In ironwood the max length allowed for a username is 150. 

I thought that we could make use of EOX_CORE_USERS_BACKEND instead of add a new setting for this.

I changed the default of settings.EOX_CORE_USERS_BACKEND to the ironwood version