### PR TITLE
Add social_core[openidconnect] as extra requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[],
     extras_require={
         "sentry": ["sentry-sdk==0.14.3"],
+        "tpa": ["social-auth-core[openidconnect]"],
     },
     scripts=[],
     license="AGPL",


### PR DESCRIPTION
Add extra dependency to social_core[openidconnect] in order to install python-jose if needed with 

eox-core[tpa]
