### PR TITLE
Filtering sentry exceptions based on traceback text regex matches

### DIFF
--- a/eox_core/integrations/sentry.py
+++ b/eox_core/integrations/sentry.py
@@ -3,7 +3,9 @@ This file implements utils used for sentry integration.
 
 See: https://github.com/eduNEXT/eox-core#integrations-with-third-party-services
 """
+import re
 import importlib
+import six
 
 from django.conf import settings
 
@@ -21,21 +23,113 @@ def load_class(full_class_string):
     return getattr(module, class_str)
 
 
-def before_send(event, hint):
+class ExceptionFilterSentry(object):
     """
-    Workaround to prevent certain exceptions to be sent to sentry.io
-    See: https://github.com/getsentry/sentry-python/issues/149#issuecomment-434448781
+    This class is a helper to filter exception events before send them to
+    sentry.io service (See: https://github.com/getsentry/sentry-python/issues/149#issuecomment-434448781).
+    It relies on the EOX_CORE_SENTRY_IGNORED_ERRORS setting. This setting is a list of rules that defines
+    which exceptions to ignore. An example below:
+
+    EOX_CORE_SENTRY_IGNORED_ERRORS = [
+        {
+            "exc_class": "openedx.core.djangoapps.user_authn.exceptions.AuthFailedError",
+            "exc_text": ["AuthFailedError.*Email or password is incorrect"]
+        },
+    ]
+    Every rule support only 2 keys for now:
+    - exc_class: the path to the exception class we want to ignore. It can only be one
+    - exc_text: a list of regex expressions to search on the last traceback frame text of the exception
+
+    In this example we have only one rule. We are ignoring AuthFailedError exceptions whose traceback text
+    has a match with the regex provided in the exc_text unique element. If exc_text contains more than one
+    regex, the exception is ignored if any of the regex matches the traceback text.
     """
-    ignored_errors = ()
-    for error in settings.EOX_CORE_SENTRY_IGNORED_ERRORS:
+    hint = None
+    exc_text = ''
+    exc_value = None
+
+    validation_exc_methods = {
+        'exc_class': 'validate_exc_class',
+        'exc_text': 'validate_exc_text'
+    }
+
+    def init_exception_values(self, event, hint):
+        """
+        Initialization of required values
+        """
+        self.hint = hint
+
+        if 'log_record' in hint:
+            self.exc_text = getattr(hint['log_record'], 'exc_text', '')
+
+        if 'exc_info' in hint:
+            _exc_type, exc_value, _tb = hint['exc_info']
+            self.exc_value = exc_value
+
+    def clear_exception_values(self):
+        """
+        Clear values from previous validation
+        """
+        self.hint = None
+        self.exc_text = ''
+        self.exc_value = None
+
+    def __call__(self, event, hint):
+        """
+        Workaround to prevent certain exceptions to be sent to sentry.io
+        See: https://github.com/getsentry/sentry-python/issues/149#issuecomment-434448781
+        """
+        self.clear_exception_values()
+        self.init_exception_values(event, hint)
+
+        ignore_event = False
+        for rule in settings.EOX_CORE_SENTRY_IGNORED_ERRORS:
+            ignore_event = self.validate_single_ignore_rule(rule)
+            # If the event meet the conditions to be ignored, break the loop
+            if ignore_event:
+                return None
+
+        return event
+
+    def validate_single_ignore_rule(self, rule):
+        """
+        Validates if a given ignored exception rule matches the current exception
+        """
+        for key, value in six.iteritems(rule):
+            # Try to get the validation method based on the current key of the rule
+            validate_method = self.validation_exc_methods.get(key, None)
+            # If validate_method is not defined, return False
+            if not validate_method:
+                return False
+            result = getattr(self, validate_method)(value)
+            if not result:
+                return False
+
+        return True
+
+    def validate_exc_class(self, exc_class_path):
+        """
+        Validate if the current exception object is an instance of the class specified
+        on the given path
+        """
+        exc_class = type(None)
         try:
-            error_class = load_class(error)
-            ignored_errors += (error_class,)
+            exc_class = load_class(exc_class_path)
         except Exception:  # pylint: disable=broad-except
             pass
-    if 'exc_info' in hint and ignored_errors:
-        _exc_type, exc_value, _tb = hint['exc_info']
-        if isinstance(exc_value, ignored_errors):
-            return None
 
-    return event
+        return isinstance(self.exc_value, exc_class)
+
+    def validate_exc_text(self, exc_text_expr):
+        """
+        Validate if any of the given regex matches with the current exception last
+        traceback text
+        """
+        if not isinstance(exc_text_expr, list):
+            exc_text_expr = [exc_text_expr]
+
+        for expr in exc_text_expr:
+            if re.search(expr, self.exc_text):
+                return True
+
+        return False

--- a/eox_core/settings/aws.py
+++ b/eox_core/settings/aws.py
@@ -125,9 +125,9 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     )
 
     if sentry_sdk is not None and sentry_integration_dsn is not None:
-        from eox_core.integrations.sentry import before_send
+        from eox_core.integrations.sentry import ExceptionFilterSentry
         sentry_sdk.init(
-            before_send=before_send,
+            before_send=ExceptionFilterSentry(),
             dsn=sentry_integration_dsn,
             integrations=[
                 DjangoIntegration(),

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -49,4 +49,20 @@ def plugin_settings(settings):
 
     # Sentry Integration
     settings.EOX_CORE_SENTRY_INTEGRATION_DSN = None
+
+    # The setting EOX_CORE_SENTRY_IGNORED_ERRORS is a list of rules that defines which exceptions to ignore.
+    # An example below:
+    # EOX_CORE_SENTRY_IGNORED_ERRORS = [
+    #     {
+    #         "exc_class": "openedx.core.djangoapps.user_authn.exceptions.AuthFailedError",
+    #         "exc_text": ["AuthFailedError.*Email or password is incorrect"]
+    #     },
+    # ]
+    # Every rule support only 2 keys for now:
+    # - exc_class: the path to the exception class we want to ignore. It can only be one
+    # - exc_text: a list of regex expressions to search on the last traceback frame text of the exception
+
+    # In this example we have only one rule. We are ignoring AuthFailedError exceptions whose traceback text
+    # has a match with the regex provided in the exc_text unique element. If exc_text contains more than one
+    # regex, the exception is ignored if any of the regex matches the traceback text.
     settings.EOX_CORE_SENTRY_IGNORED_ERRORS = []


### PR DESCRIPTION
This PR implements a callable to ignore specific exceptions to be sent to sentry.io service. The motivation behind this PR is the fact that Sentry dashboard gets a bit noisy with lots of exception events that are not relevant since they're not truly errors.

The exceptions can be ignored based on exception class match or last traceback text regex match

@diegomillan 
@morenol 
@felipemontoya 