### PR TITLE
Do not install django-oauth-provider

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,6 @@
 celery
 djangorestframework
 django-filter
-django-oauth2-provider
 django-oauth-toolkit
 django-waffle
 edx-proctoring

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,6 @@ django-filter==1.0.4      # via -c requirements/constraints.txt, -r requirements
 django-ipware==3.0.1      # via edx-proctoring
 django-model-utils==3.0.0  # via -c requirements/constraints.txt, edx-proctoring
 django-oauth-toolkit==1.1.3  # via -c requirements/constraints.txt, -r requirements/base.in
-django-oauth2-provider==0.2.6.1  # via -c requirements/constraints.txt, -r requirements/base.in
 django-waffle==0.12.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions, edx-proctoring
 django-webpack-loader==0.7.0  # via edx-proctoring
 django==1.11.29           # via django-crum, django-model-utils, django-oauth-toolkit, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, event-tracking, jsonfield, rest-condition
@@ -31,7 +30,7 @@ future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 jsonfield==2.0.2          # via -c requirements/constraints.txt, edx-proctoring
 kombu==3.0.37             # via celery
-newrelic==5.18.0.148      # via edx-django-utils
+newrelic==5.20.1.150      # via edx-django-utils
 oauthlib==3.1.0           # via django-oauth-toolkit
 pbr==5.5.0                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -44,7 +43,6 @@ pytz==2020.1              # via celery, django, edx-proctoring, event-tracking
 requests==2.24.0          # via django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-shortuuid==0.5.0          # via django-oauth2-provider
 six==1.15.0               # via edx-drf-extensions, edx-opaque-keys, event-tracking, pyjwkest, python-dateutil, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,6 +1,3 @@
--e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1  # via -r requirements/github.in
--e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3  # via  edx-drf-extensions, edx-proctoring, rest-condition
-
 celery==3.1.25            # via -c requirements/constraints.txt, -r requirements/base.txt, event-tracking
 django-filter==1.0.4      # via -c requirements/constraints.txt, -r requirements/base.txt
 django-model-utils==3.0.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-proctoring

--- a/requirements/django22.txt
+++ b/requirements/django22.txt
@@ -1,6 +1,7 @@
 celery==3.1.26.post2
 Django==2.2.16
 djangorestframework==3.9.4
+django-oauth2-provider
 django-filter==2.2.0
 django-model-utils==4.0.0
 django-oauth-toolkit==1.3.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,7 +17,6 @@ configparser==4.0.2       # via pylint
 coverage==5.3             # via -r requirements/test.in
 django-crum==0.7.7        # via -r requirements/base.txt, edx-proctoring
 django-ipware==3.0.1      # via -r requirements/base.txt, edx-proctoring
-django-oauth2-provider==0.2.6.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-webpack-loader==0.7.0  # via -r requirements/base.txt, edx-proctoring
 djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
@@ -39,7 +38,7 @@ lazy-object-proxy==1.5.1  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==5.0.0     # via pytest
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.20.1.150      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, django-oauth-toolkit
 pbr==5.5.0                # via -r requirements/base.txt, stevedore
 pluggy==0.6.0             # via pytest
@@ -58,7 +57,6 @@ pytz==2020.1              # via -r requirements/base.txt, celery, django, edx-pr
 requests==2.24.0          # via -r requirements/base.txt, django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-shortuuid==0.5.0          # via -r requirements/base.txt, django-oauth2-provider
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.15.0               # via -r requirements/base.txt, astroid, edx-drf-extensions, edx-opaque-keys, event-tracking, faker, mock, more-itertools, pyjwkest, pylint, pytest, python-dateutil, singledispatch, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -22,5 +22,5 @@ six==1.15.0               # via packaging, pathlib2, tox, virtualenv
 toml==0.10.1              # via tox
 tox==3.20.0               # via -r requirements/tox.in
 typing==3.7.4.3           # via importlib-resources
-virtualenv==20.0.31       # via tox
+virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
django-oauth-provider has problems when it is installed ironwood. (in ironwood it is used edx-django-oauth-provider)