### PR TITLE
Fix enrollment import error in Juniper

### DIFF
--- a/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py
@@ -11,8 +11,6 @@ import logging
 
 from course_modes.models import CourseMode
 from django.contrib.auth.models import User
-from enrollment import api
-from enrollment.errors import CourseEnrollmentExistsError, CourseModeNotFoundError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -24,6 +22,19 @@ from student.models import CourseEnrollment
 from eox_core.edxapp_wrapper.backends.edxfuture_i_v1 import get_program
 from eox_core.edxapp_wrapper.coursekey import get_valid_course_key, validate_org
 from eox_core.edxapp_wrapper.users import check_edxapp_account_conflicts
+
+try:
+    # For Hawthorn and Ironwood versions.
+    from enrollment import api
+    from enrollment.errors import CourseEnrollmentExistsError, CourseModeNotFoundError
+except ImportError:
+    # For Juniper versions.
+    from openedx.core.djangoapps.enrollments import api  # pylint: disable=ungrouped-imports
+    from openedx.core.djangoapps.enrollments.errors import (  # pylint: disable=ungrouped-imports
+        CourseEnrollmentExistsError,
+        CourseModeNotFoundError
+    )
+
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR fixes the following error in Juniper:

![Screenshot from 2020-11-03 16-46-38](https://user-images.githubusercontent.com/64440265/98038953-529a4600-1df4-11eb-8aee-a3e0d690eb52.png)


This error was raised because in juniper enrollments API is located in /openedx/core/djangoapps/enrollments  and not in /common/djangoapps/enrollment. This was done in edx/edx-platform//pull/20702

- [x] Tested in Juniper
- [x] Tested in Ironwood