### PR TITLE
Fix django-filters in Juniper

### DIFF
--- a/eox_core/api/data/v1/filters.py
+++ b/eox_core/api/data/v1/filters.py
@@ -30,16 +30,16 @@ class UserFilter(BaseDataApiFilter):
     date_joined = django_filters.DateTimeFromToRangeFilter()
 
     # Filtering by user profile fields
-    name = django_filters.CharFilter(name="profile__name", lookup_expr="icontains")
-    language = django_filters.CharFilter(name="profile__language", lookup_expr="iexact")
-    year_of_birth = django_filters.RangeFilter(name="profile__year_of_birth")
-    gender = django_filters.CharFilter(name="profile__gender", lookup_expr="iexact")
-    mailing_address = django_filters.CharFilter(name="profile__mailing_address", lookup_expr="iexact")
-    city = django_filters.CharFilter(name="profile__city", lookup_expr="icontains")
-    country = django_filters.CharFilter(name="profile__country", lookup_expr="icontains")
+    name = django_filters.CharFilter(field_name="profile__name", lookup_expr="icontains")
+    language = django_filters.CharFilter(field_name="profile__language", lookup_expr="iexact")
+    year_of_birth = django_filters.RangeFilter(field_name="profile__year_of_birth")
+    gender = django_filters.CharFilter(field_name="profile__gender", lookup_expr="iexact")
+    mailing_address = django_filters.CharFilter(field_name="profile__mailing_address", lookup_expr="iexact")
+    city = django_filters.CharFilter(field_name="profile__city", lookup_expr="icontains")
+    country = django_filters.CharFilter(field_name="profile__country", lookup_expr="icontains")
 
     # Filtering by user signup source fields
-    site = django_filters.CharFilter(name="usersignupsource__site", lookup_expr='iexact')
+    site = django_filters.CharFilter(field_name="usersignupsource__site", lookup_expr='iexact')
 
     class Meta(object):
         """
@@ -73,7 +73,7 @@ class CourseEnrollmentFilter(BaseDataApiFilter):
     created = django_filters.DateTimeFromToRangeFilter()
     is_active = django_filters.BooleanFilter()
     mode = django_filters.CharFilter(lookup_expr='icontains')
-    site = django_filters.CharFilter(name="user__usersignupsource__site", lookup_expr='iexact')
+    site = django_filters.CharFilter(field_name="user__usersignupsource__site", lookup_expr='iexact')
 
     def filter_course_id(self, queryset, name, value):
         """
@@ -119,8 +119,8 @@ class GeneratedCerticatesFilter(BaseDataApiFilter):
     DOWNLOADABLE = 'downloadable'
     ALL = 'all'
 
-    site = django_filters.CharFilter(name="user__usersignupsource__site", lookup_expr='iexact')
-    username = django_filters.CharFilter(name="user__username", lookup_expr='icontains')
+    site = django_filters.CharFilter(field_name="user__usersignupsource__site", lookup_expr='iexact')
+    username = django_filters.CharFilter(field_name="user__username", lookup_expr='icontains')
     created_date = django_filters.DateTimeFromToRangeFilter()
     course_id = django_filters.CharFilter(method="filter_course_id")
     status = django_filters.CharFilter(method="filter_status")
@@ -184,9 +184,9 @@ class ProctoredExamStudentAttemptFilter(BaseDataApiFilter):
     """
     TODO: add me
     """
-    site = django_filters.CharFilter(name="user__usersignupsource__site", lookup_expr='iexact')
-    course_id = django_filters.CharFilter(name="proctored_exam__course_id", lookup_expr='iexact')
-    exam_name = django_filters.CharFilter(name="proctored_exam__exam_name", lookup_expr='iexact')
+    site = django_filters.CharFilter(field_name="user__usersignupsource__site", lookup_expr='iexact')
+    course_id = django_filters.CharFilter(field_name="proctored_exam__course_id", lookup_expr='iexact')
+    exam_name = django_filters.CharFilter(field_name="proctored_exam__exam_name", lookup_expr='iexact')
 
     class Meta(object):
         """

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,8 @@
 
 celery
 djangorestframework
-django-filter
+django-filter==1.1.0; python_version == '2.7'
+django-filter==2.2.0; python_version > '2.7'
 django-oauth-toolkit
 django-waffle
 edx-proctoring

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,11 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.25            # via -c requirements/constraints.txt, -r requirements/base.in, event-tracking
-certifi==2020.6.20        # via requests
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
-django-crum==0.7.7        # via edx-proctoring
-django-filter==1.0.4      # via -c requirements/constraints.txt, -r requirements/base.in
-django-ipware==3.0.1      # via edx-proctoring
+django-crum==0.7.9        # via edx-django-utils, edx-proctoring
+django-filter==1.1.0 ; python_version == "2.7"  # via -r requirements/base.in
+django-ipware==3.0.2      # via edx-proctoring
 django-model-utils==3.0.0  # via -c requirements/constraints.txt, edx-proctoring
 django-oauth-toolkit==1.1.3  # via -c requirements/constraints.txt, -r requirements/base.in
 django-waffle==0.12.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions, edx-proctoring
@@ -20,7 +20,7 @@ django-webpack-loader==0.7.0  # via edx-proctoring
 django==1.11.29           # via django-crum, django-model-utils, django-oauth-toolkit, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, event-tracking, jsonfield, rest-condition
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-proctoring, rest-condition
-edx-django-utils==3.8.0   # via edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.11.0  # via edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==2.0.1  # via -c requirements/constraints.txt, edx-proctoring
 edx-opaque-keys[django]==0.4.4  # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-proctoring
 edx-proctoring==1.5.7     # via -c requirements/constraints.txt, -r requirements/base.in
@@ -30,20 +30,20 @@ future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 jsonfield==2.0.2          # via -c requirements/constraints.txt, edx-proctoring
 kombu==3.0.37             # via celery
-newrelic==5.20.1.150      # via edx-django-utils
+newrelic==5.22.1.152      # via edx-django-utils
 oauthlib==3.1.0           # via django-oauth-toolkit
-pbr==5.5.0                # via stevedore
+pbr==5.5.1                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
-pycryptodomex==3.9.8      # via edx-proctoring, pyjwkest
+pycryptodomex==3.9.9      # via edx-proctoring, pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client
 pymongo==3.11.0           # via edx-opaque-keys, event-tracking
 python-dateutil==2.8.1    # via edx-drf-extensions, edx-proctoring
-pytz==2020.1              # via celery, django, edx-proctoring, event-tracking
-requests==2.24.0          # via django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
+pytz==2020.4              # via celery, django, edx-proctoring, event-tracking
+requests==2.25.0          # via django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via edx-drf-extensions, edx-opaque-keys, event-tracking, pyjwkest, python-dateutil, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-urllib3==1.25.10          # via requests
+urllib3==1.26.2           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,7 +18,6 @@ pycodestyle==2.5.0
 # Keep same platform version
 celery==3.1.25
 djangorestframework==3.6.3
-django-filter==1.0.4
 django-model-utils==3.0.0
 django-oauth-toolkit==1.1.3
 django-oauth2-provider==0.2.6.1

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,5 +1,5 @@
 celery==3.1.25            # via -c requirements/constraints.txt, -r requirements/base.txt, event-tracking
-django-filter==1.0.4      # via -c requirements/constraints.txt, -r requirements/base.txt
+django-filter==1.1.0 ; python_version == "2.7"  # via -r requirements/base.txt
 django-model-utils==3.0.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-proctoring
 django-oauth-toolkit==1.1.3  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-waffle==0.12.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions, edx-proctoring

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,18 +8,18 @@ amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 astroid==1.6.6            # via pylint
 atomicwrites==1.4.0       # via pytest
-attrs==20.2.0             # via pytest
+attrs==20.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-certifi==2020.6.20        # via -r requirements/base.txt, requests
+certifi==2020.11.8        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 configparser==4.0.2       # via pylint
 coverage==5.3             # via -r requirements/test.in
-django-crum==0.7.7        # via -r requirements/base.txt, edx-proctoring
-django-ipware==3.0.1      # via -r requirements/base.txt, edx-proctoring
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-proctoring
+django-ipware==3.0.2      # via -r requirements/base.txt, edx-proctoring
 django-webpack-loader==0.7.0  # via -r requirements/base.txt, edx-proctoring
 djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.11.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-opaque-keys[django]==0.4.4  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions, edx-proctoring
 edx-rest-api-client==5.2.1  # via -r requirements/base.txt, edx-proctoring
 enum34==1.1.10            # via astroid
@@ -38,14 +38,14 @@ lazy-object-proxy==1.5.1  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==5.0.0     # via pytest
-newrelic==5.20.1.150      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, django-oauth-toolkit
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pluggy==0.6.0             # via pytest
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 py==1.9.0                 # via pytest
 pycodestyle==2.5.0        # via -c requirements/constraints.txt, -r requirements/test.in
-pycryptodomex==3.9.8      # via -r requirements/base.txt, edx-proctoring, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, edx-proctoring, pyjwkest
 pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, edx-rest-api-client
 pylint==1.9.3             # via -c requirements/constraints.txt, -r requirements/test.in
@@ -53,8 +53,8 @@ pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys, event
 pytest-django==3.3.3      # via -c requirements/constraints.txt, -r requirements/test.in
 pytest==3.6.3             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, edx-proctoring, faker
-pytz==2020.1              # via -r requirements/base.txt, celery, django, edx-proctoring, event-tracking
-requests==2.24.0          # via -r requirements/base.txt, django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
+pytz==2020.4              # via -r requirements/base.txt, celery, django, edx-proctoring, event-tracking
+requests==2.25.0          # via -r requirements/base.txt, django-oauth-toolkit, edx-drf-extensions, edx-rest-api-client, pyjwkest, slumber
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 singledispatch==3.4.0.3   # via astroid, pylint
@@ -63,7 +63,7 @@ slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 testfixtures==6.4.3       # via -c requirements/constraints.txt, -r requirements/test.in
 text-unidecode==1.3       # via faker
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests
 wrapt==1.12.1             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
**Description and justification**

This PR fixes users'/course enrollment/ generated certificates/proctored exams filter error, caused by django-filter forward compatibility issue. Also, makes it backward compatible.

The main issue that we have here is that in django-filter v1.0.4 -version used in Ironwood- there's a keyword `name` that was deprecated after v2.0.0 -Juniper uses v2.2.0-, then or we use the deprecated keyword `name` or we use the replacement `field_name`. 

Solution: 

Change name to field_name and change Django-filter to a version != than 1.0.4 when using python 2.7. Version 1.1.0 supports name and field_name keyword: https://github.com/carltongibson/django-filter/blob/1.1.0/django_filters/filters.py#L92