### PR TITLE
Remove api user info permission.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Change Log
 Unreleased
 ----------
 
+Removed
+~~~~~~~
+* EoxCoreAPIPermission from UserInfo APIView
+
 [3.2.0] - 2020-11-18
 --------------------
 

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -456,7 +456,6 @@ class UserInfo(APIView):
     Can use Oauth2/Session
     """
     authentication_classes = (BearerAuthentication, SessionAuthentication)
-    permission_classes = (EoxCoreAPIPermission,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, format=None):  # pylint: disable=redefined-builtin


### PR DESCRIPTION
## Description
That permission doesn't make a lot of sense since this view returns the current user information and doesn't make anything else, and due to request.user is set by BearerAuthentication or SessionAuthentication the information returned always will belong to the current user.