### PR TITLE
Allow inactive users in UserInfo api view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 Unreleased
 ----------
 
+Added
+~~~~~
+* BearerAuthenticationAllowInactiveUser backend.
+* IsAuthenticated permission to UserInfo api view.
+
 [3.3.0] - 2020-12-16
 --------------------
 

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -12,6 +12,7 @@ from django.utils import six
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import APIException, NotFound, ValidationError
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,7 +27,7 @@ from eox_core.api.v1.serializers import (
     EdxappUserSerializer,
     WrittableEdxappUserSerializer,
 )
-from eox_core.edxapp_wrapper.bearer_authentication import BearerAuthentication
+from eox_core.edxapp_wrapper.bearer_authentication import BearerAuthentication, BearerAuthenticationAllowInactiveUser
 from eox_core.edxapp_wrapper.enrollments import create_enrollment, delete_enrollment, get_enrollment, update_enrollment
 from eox_core.edxapp_wrapper.pre_enrollments import (
     create_pre_enrollment,
@@ -455,7 +456,8 @@ class UserInfo(APIView):
     Auth-only view to check some basic info about the current user
     Can use Oauth2/Session
     """
-    authentication_classes = (BearerAuthentication, SessionAuthentication)
+    authentication_classes = (BearerAuthenticationAllowInactiveUser, SessionAuthentication)
+    permission_classes = (IsAuthenticated,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, format=None):  # pylint: disable=redefined-builtin

--- a/eox_core/edxapp_wrapper/backends/bearer_authentication_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/bearer_authentication_j_v1.py
@@ -14,3 +14,21 @@ def get_bearer_authentication():
         BearerAuthentication function.
     """
     return BearerAuthentication
+
+
+def get_bearer_authentication_allow_inactive_user():  # pylint: disable=invalid-name
+    """Allow to get the class BearerAuthenticationAllowInactiveUser from
+    https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/lib/api/authentication.py
+
+    Returns:
+        BearerAuthenticationAllowInactiveUser class.
+    """
+    try:
+        from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+    except ImportError:
+        # This import is just for backwards compatibility in ironwood versions.
+        from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+
+        return OAuth2AuthenticationAllowInactiveUser
+
+    return BearerAuthenticationAllowInactiveUser

--- a/eox_core/edxapp_wrapper/backends/bearer_authentication_j_v1_test.py
+++ b/eox_core/edxapp_wrapper/backends/bearer_authentication_j_v1_test.py
@@ -13,3 +13,18 @@ def get_bearer_authentication():
     except ImportError:
         BearerAuthentication = object
     return BearerAuthentication
+
+
+def get_bearer_authentication_allow_inactive_user():  # pylint: disable=invalid-name
+    """Allow to get the class BearerAuthenticationAllowInactiveUser from
+    https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/lib/api/authentication.py
+
+    Returns:
+        BearerAuthentication function.
+    """
+    try:
+        from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+    except ImportError:
+        BearerAuthenticationAllowInactiveUser = object
+
+    return BearerAuthenticationAllowInactiveUser

--- a/eox_core/edxapp_wrapper/bearer_authentication.py
+++ b/eox_core/edxapp_wrapper/bearer_authentication.py
@@ -14,4 +14,13 @@ def get_bearer_authentication():
     return backend.get_bearer_authentication()
 
 
+def get_bearer_authentication_allow_inactive_user():  # pylint: disable=invalid-name
+    """ Gets BearerAuthentication class. """
+    backend_function = settings.EOX_CORE_BEARER_AUTHENTICATION
+    backend = import_module(backend_function)
+
+    return backend.get_bearer_authentication_allow_inactive_user()
+
+
 BearerAuthentication = get_bearer_authentication()  # pylint: disable=invalid-name
+BearerAuthenticationAllowInactiveUser = get_bearer_authentication_allow_inactive_user()  # pylint: disable=invalid-name


### PR DESCRIPTION
## Description
The current version only allows active users, so this fails if the user is new and doesn't make the validation, so this change adds a new backend for inactive users and edit the authentication classes for the UserInfo api view.