### PR TITLE
Add EoxCoreAPIPermission to UserInfo APIView

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Change Log
 Unreleased
 ----------
 
+Added
+~~~~~
+* Revert previous change in order to add EoxCoreAPIPermission to UserInfo APIView.
+
 [3.3.0] - 2020-12-16
 --------------------
 

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -456,6 +456,7 @@ class UserInfo(APIView):
     Can use Oauth2/Session
     """
     authentication_classes = (BearerAuthentication, SessionAuthentication)
+    permission_classes = (EoxCoreAPIPermission,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, format=None):  # pylint: disable=redefined-builtin


### PR DESCRIPTION
## Description
revert changes of https://github.com/eduNEXT/eox-core/pull/121 since the view my_user_info in https://github.com/edx/edx-platform/blob/master/lms/djangoapps/mobile_api/users/views.py  already returns the necessary data without special permissions.
