### PR TITLE
Add a new suite of integration tests

### DIFF
--- a/eox_core/tests/integration/README.rst
+++ b/eox_core/tests/integration/README.rst
@@ -1,0 +1,356 @@
+Integration tests
+=================
+
+.. contents::
+
+Enrollments API
++++++++++++++++
+
+Running
+-------
+
+You can run the tests using the make target
+
+.. code-block:: console
+
+    $ make python-test
+
+This test make several assumptions about the current state of the database
+in case your setup differs you will have to modify ``test_data`` accordingly.
+
+Data requirements
+-----------------
+The test_data file includes the data necessary to run each test. It's content
+must reflect the current database configuration of the platform you
+are running the tests. The provided test are meant to be run on a devstack
+environment with the following requirements:
+
+1. There should be a DOT application with client_id ``apiclient`` and
+   client_secret ``apisecret``
+2. There should be two sites available with Domain Name ``site1.localhost`` and
+   ``site2.localhost``
+3. Each site should have one user with username ``user_site1`` and email
+   ``user_site1@example.com`` for ``site1`` and ``user_site2`` and
+   ``user_site2@example.com`` for ``site2``.
+4. ``site1`` should have a ``site1_course`` with id
+   ``course-v1:edX+DemoX+Demo_Course`` this course should not be available on
+   ``site2``. You must enable the ``audit`` and ``honor`` modes for ``site1_course``
+
+``test_data`` layout
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: json
+
+    {
+        "site1_data": {
+            "fake_user": "fakeuser",
+            "user_id": "user_site1",
+            "user_email": "user_site1@example.com",
+            "host": "site1.localhost",
+            "course": {
+                "id": "course-v1:edX+DemoX+Demo_Course",
+                "mode": "audit"
+            },
+            "base_url": "http://site1.localhost:18000",
+            "client_id": "apiclient",
+            "client_secret": "apisecret"
+        },
+        "site2_data": {
+            "user_id": "user_site2",
+            "user_email": "user_site2@example.com",
+            "host": "site2.localhost",
+            "base_url": "http://site2.localhost:18000",
+            "client_id": "apiclient",
+            "client_secret": "apisecret"
+        }
+    }
+
+Current Tests
+-------------
+
+Each test from this suite performs an http request to guarantee
+that all CRUD operations are handled correctly. Each test case
+is detailed below, including arguments used in each request
+with data from ``test_data``.
+
+Create
+~~~~~~
+
+  .. code::
+
+    SetUp   1-7: Delete previous enrollments
+
+  1. Create a valid enrollment  ✔
+  2. Create a valid enrollment using force ✔
+  3. Create an enrollment with invalid user ❌
+  4. Create an enrollment with user from another site ❌
+  5. Create an enrollment with invalid course ❌
+  6. Create an enrollment with course from another site ❌
+  7. Create an enrollment with invalid mode ❌
+
+
+**Requests arguments**
+
+.. list-table::
+
+
+  * - Nº
+    - Method
+    - User
+    - Course
+    - Mode
+    - Site
+    - Force
+
+  * - 1
+    - POST
+    - ``user_site1``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``False``
+
+  * - 2
+    - POST
+    - ``user_site1``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``True``
+
+  * - 3
+    - POST
+    - ``site1_fakeuser``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``False``
+
+  * - 4
+    - POST
+    - ``user_site2``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``False``
+
+  * - 5
+    - POST
+    - ``user_site1``
+    - ``site1_fakecourse``
+    - ``audit``
+    - ``site1``
+    - ``True``
+
+  * - 6
+    - POST
+    - ``user_site2``
+    - ``site1_course``
+    - ``audit``
+    - ``site2``
+    - ``True``
+
+  * - 7
+    - POST
+    - ``user_site1``
+    - ``site1_course``
+    - ``Masters``
+    - ``site1``
+    - ``True``
+
+READ
+~~~~
+
+  .. code::
+
+    SetUp   1,3: Create default enrollment
+    SetUp     2: Delete previous enrollments
+
+  1. Read a valid enrollment  ✔
+  2. Read a non-existent enrollment ❌
+  3. Read an existing enrollment from another site ❌
+
+**Requests arguments**
+
+.. list-table::
+
+  * - Nº
+    - Method
+    - User
+    - Course
+    - Site
+
+  * - 1
+    - GET
+    - ``user_site1``
+    - ``site1_course``
+    - ``site1``
+
+  * - 2
+    - GET
+    - ``user_site1``
+    - ``site1_course``
+    - ``site1``
+
+  * - 3
+    - GET
+    - ``user_site2``
+    - ``site1_course``
+    - ``site2``
+
+UPDATE
+~~~~~~
+
+  .. code::
+
+    SetUp   1-3, 6-7: Create default enrollment
+    SetUp        4-5: Delete previous enrollments
+
+  1. Change ``is_active`` ✔
+  2. Change mode ✔
+  3. Change to invalid mode ❌
+  4. Change ``is_active`` from invalid enrollment ❌
+  5. Change mode from invalid enrollment ❌
+  6. Change ``is_active`` with POST force ✔
+  7. Change mode with POST force ✔
+
+**Requests arguments**
+
+.. list-table::
+
+  * - Nº
+    - Method
+    - User
+    - Course
+    - Mode
+    - Site
+    - ``is_active``
+
+  * - 1
+    - PUT
+    - ``user_site1``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``False``
+
+  * - 2
+    - PUT
+    - ``user_site1``
+    - ``site1_course``
+    - ``honor``
+    - ``site1``
+    - ``True``
+
+  * - 3
+    - PUT
+    - ``user_site1``
+    - ``site1_course``
+    - ``masters``
+    - ``site1``
+    - ``True``
+
+  * - 4
+    - PUT
+    - ``user_site1``
+    - ``site1_course``
+    - ``honor``
+    - ``site1``
+    - ``True``
+
+  * - 5
+    - PUT
+    - ``user_site1``
+    - ``site1_course``
+    - ``audit``
+    - ``site1``
+    - ``False``
+
+.. list-table::
+
+  * - Nº
+    - Method
+    - User
+    - Course
+    - Mode
+    - Site
+    - ``is_active``
+    - Force
+
+  * - 6
+    - POST
+    - ``user_site1``
+    - ``site1_course``
+    - ``audit``
+    - ``site2``
+    - ``False``
+    - ``True``
+
+  * - 7
+    - POST
+    - ``user_site1``
+    - ``site1_course``
+    - ``masters``
+    - ``site1``
+    - ``True``
+    - ``True``
+
+DELETE
+~~~~~~
+
+  .. code::
+
+    SetUp   1,3: Create default enrollment
+    SetUp     2: Delete previous enrollments
+
+  1. Delete a valid enrollment  ✔
+  2. Delete a non-existent enrollment ❌
+  3. Delete an existing enrollment from another site ❌
+
+**Requests arguments**
+
+.. list-table::
+
+  * - Nº
+    - Method
+    - User
+    - Course
+    - Site
+
+  * - 1
+    - DELETE
+    - ``user_site1``
+    - ``site1_course``
+    - ``site1``
+
+  * - 2
+    - DELETE
+    - ``user_site1``
+    - ``site1_course``
+    - ``site1``
+
+  * - 3
+    - DELETE
+    - ``user_site2``
+    - ``site1_course``
+    - ``site2``
+
+Testing on stage
+----------------
+In case you want to run the test suite on a staging server, first you must
+alter the ``test_data`` file.
+The prerequisites mentioned on `Data requirements`_ still apply;
+
+1. You must have access to 2 different sites. Change:
+   ``site1_data['base_url']``, ``site1_data['host']``,
+   ``site2_data['base_url']``, ``site2_data['host']``
+   depending on their domain name.
+2. You must have an client_id and client_secret for each site. Change:
+   ``site1_data['client_id']``, ``site1_data['client_secret']``,
+   ``site2_data['client_id']``, ``site2_data['client_secret']``
+3. You must have one user for each site. Change:
+   ``site1_data['user_id']``, ``site1_data['user_email']``,
+   ``site2_data['user_id']``, ``site2_data['user_email']``
+4. You must have a course on site 1 that is **not** available on site 2
+   with audit and honor as available modes.  Change:
+   ``site1_data['course']['id']``

--- a/eox_core/tests/integration/test_data
+++ b/eox_core/tests/integration/test_data
@@ -1,0 +1,23 @@
+{
+    "site1_data": {
+        "fake_user": "fakeuser",
+        "user_id": "user_site1",
+        "user_email": "user_site1@example.com",
+        "host": "site1.localhost",
+        "course": {
+            "id": "course-v1:edX+DemoX+Demo_Course",
+            "mode": "audit"
+        },
+        "base_url": "http://site1.localhost:18000",
+        "client_id": "apiclient",
+        "client_secret": "apisecret"
+    },
+    "site2_data": {
+        "user_id": "user_site2",
+        "user_email": "user_site2@example.com",
+        "host": "site2.localhost",
+        "base_url": "http://site2.localhost:18000",
+        "client_id": "apiclient",
+        "client_secret": "apisecret"
+    }
+}

--- a/eox_core/tests/integration/test_enrollment_integration.py
+++ b/eox_core/tests/integration/test_enrollment_integration.py
@@ -1,0 +1,586 @@
+"""
+Integration test suite.
+
+This suite performs multiple http requests to guarantee
+that all CRUD operations are handled correctly.
+"""
+import json
+from os import environ
+
+import pytest
+import requests
+from django.test import TestCase
+
+
+@pytest.mark.skipif(bool(environ.get("CI")), reason="Do not run on CI")
+class TestEnrollmentIntegration(TestCase):  # pragma: no cover
+    # pylint: disable=too-many-public-methods
+    """Test suite"""
+    data = {}
+
+    @classmethod
+    def setUpClass(cls):
+        with open("eox_core/tests/integration/test_data") as file_obj:
+            cls.data = json.load(file_obj)
+        cls.data["endpoint"] = "eox-core/api/v1/enrollment/"
+        site1_data = {
+            "client_id": cls.data["site1_data"]["client_id"],
+            "client_secret": cls.data["site1_data"]["client_secret"],
+            "grant_type": "client_credentials",
+        }
+        site2_data = {
+            "client_id": cls.data["site2_data"]["client_id"],
+            "client_secret": cls.data["site2_data"]["client_secret"],
+            "grant_type": "client_credentials",
+        }
+        request_url = "{}/{}".format(
+            cls.data["site1_data"]["base_url"], "oauth2/access_token/"
+        )
+        response_site1 = requests.post(request_url, data=site1_data)
+        response_site1.raise_for_status()
+        cls.data["site1_data"]["token"] = response_site1.json()["access_token"]
+        request_url = "{}/{}".format(
+            cls.data["site2_data"]["base_url"], "oauth2/access_token/"
+        )
+        response_site2 = requests.post(request_url, data=site2_data)
+        response_site2.raise_for_status()
+        cls.data["site2_data"]["token"] = response_site2.json()["access_token"]
+
+    @classmethod
+    def tearDownClass(cls):
+        delete_enrollment(cls.data)
+
+    def test_read_valid_email_course(self):
+        # pylint: disable=invalid-name
+        """
+        Get a valid enrollment
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        expected_response = {
+            "username": site1_data["user_id"],
+            "course_id": data["course_id"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.get(request_url, data=data, headers=headers)
+        response_content = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(expected_response, response_content)
+
+    def test_read_invalid_enrollment(self):
+        # pylint: disable=invalid-name
+        """
+        Get a invalid enrollment (doesn't exist)
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "username": site1_data["user_id"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.get(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_read_invalid_enrollment_for_site(self):
+        # pylint: disable=invalid-name
+        """
+        Get a invalid enrollment (enrollment from other site)
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        site2_data = self.data["site2_data"]
+        data = {
+            "username": site1_data["user_id"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site2_data["token"]),
+            "Host": site2_data["host"],
+        }
+        request_url = "{}/{}".format(site2_data["base_url"], self.data["endpoint"])
+
+        response = requests.get(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_enrollment_valid_user_mode_course(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid user, valid course,
+        valid mode
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "mode": site1_data["course"]["mode"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_force_create_enrollment_valid_user_mode_course(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid user, valid course,
+        valid mode using force
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "mode": site1_data["course"]["mode"],
+            "force": True,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_valid_course_mode_invalid_user(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid course, valid mode,
+        and a non-existent user
+        """
+        site1_data = self.data["site1_data"]
+        data = {
+            "username": site1_data["fake_user"],
+            "course_id": site1_data["course"]["id"],
+            "mode": site1_data["course"]["mode"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_valid_course_mode_invalid_user_for_site(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid course, valid mode,
+        and a user from another site
+        """
+        site1_data = self.data["site1_data"]
+        site2_data = self.data["site2_data"]
+        data = {
+            "email": site2_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "mode": site1_data["course"]["mode"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 202)
+
+    def test_create_valid_user_mode_invalid_course(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid user, valid mode,
+        and non-existent course
+        """
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": "fake_course_id",
+            "mode": "audit",
+            "force": True,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_valid_user_mode_invalid_course_for_site(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid user, valid mode,
+        and a course from another site
+        """
+        site1_data = self.data["site1_data"]
+        site2_data = self.data["site2_data"]
+        data = {
+            "email": site2_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "mode": site1_data["course"]["mode"],
+            "force": True,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site2_data["token"]),
+            "Host": site2_data["host"],
+        }
+        request_url = "{}/{}".format(site2_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+
+    # NOTE: Mode changes are not working correctly on devstack
+    def test_force_create_valid_user_course_invalid_mode(self):
+        # pylint: disable=invalid-name
+        """
+        Create enrollment with a valid user, valid course,
+        and a not available mode
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "mode": "masters",
+            "force": 1,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_valid_enrollment(self):
+        # pylint: disable=invalid-name
+        """
+        Delete a valid enrollment
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.delete(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_delete_invalid_enrollment(self):
+        # pylint: disable=invalid-name
+        """
+        Delete a invalid enrollment(doesn't exist)
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.delete(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_invalid_enrollment_for_site(self):
+        # pylint: disable=invalid-name
+        """
+        Delete a invalid enrollment (enrollment from other site)
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        site2_data = self.data["site2_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site2_data["token"]),
+            "Host": site2_data["host"],
+        }
+        request_url = "{}/{}".format(site2_data["base_url"], self.data["endpoint"])
+
+        response = requests.delete(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_valid_enrollment_change_is_active(self):
+        # pylint: disable=invalid-name
+        """
+        Update an existing enrollment; change is_active flag
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": False,
+            "mode": site1_data["course"]["mode"],
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        expected_response = {
+            "user": site1_data["user_id"],
+            "is_active": False,
+            "course_id": data["course_id"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+        response_content = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(expected_response, response_content)
+
+    # NOTE: Mode changes are not working correctly on devstack
+    def test_update_valid_enrollment_change_valid_mode(self):
+        # pylint: disable=invalid-name
+        """
+        Update an existing enrollment; change mode
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": True,
+            "mode": "honor",
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        expected_response = {
+            "user": site1_data["user_id"],
+            "is_active": True,
+            "course_id": data["course_id"],
+            "mode": "honor",
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+        response_content = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(expected_response, response_content)
+
+    def test_update_valid_enrollment_change_invalid_mode(self):
+        # pylint: disable=invalid-name
+        """
+        Update an existing enrollment; change to invalid mode
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": True,
+            "mode": "masters",
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_invalid_enrollment_change_valid_mode(self):
+        # pylint: disable=invalid-name
+        """
+        Update an non-existent enrollment; change mode
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": True,
+            "mode": "honor",
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 202)
+
+    def test_update_invalid_enrollment_change_is_active(self):
+        # pylint: disable=invalid-name
+        """
+        Update an non-existent enrollment; change is_active flag
+        """
+        delete_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": False,
+            "mode": "audit",
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+
+        self.assertEqual(response.status_code, 202)
+
+    def test_update_valid_enrollment_change_is_active_force_post(self):
+        # pylint: disable=invalid-name
+        """
+        Update an existing enrollment using POST with force=True;
+        change is_active flag
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": False,
+            "mode": site1_data["course"]["mode"],
+            "force": True,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        expected_response = {
+            "username": site1_data["user_id"],
+            "is_active": False,
+            "course_id": data["course_id"],
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.post(request_url, data=data, headers=headers)
+        response_content = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(expected_response, response_content)
+
+    # NOTE: Mode changes are not working correctly on devstack
+    def test_update_valid_enrollment_change_valid_mode_force_post(self):
+        # pylint: disable=invalid-name
+        """
+        Update an existing enrollment; change mode
+        """
+        create_enrollment(self.data)
+        site1_data = self.data["site1_data"]
+        data = {
+            "email": site1_data["user_email"],
+            "course_id": site1_data["course"]["id"],
+            "is_active": True,
+            "mode": "honor",
+            "force": True,
+        }
+        headers = {
+            "Authorization": "Bearer {}".format(site1_data["token"]),
+            "Host": site1_data["host"],
+        }
+        expected_response = {
+            "user": site1_data["user_id"],
+            "is_active": True,
+            "course_id": data["course_id"],
+            "mode": "honor",
+        }
+        request_url = "{}/{}".format(site1_data["base_url"], self.data["endpoint"])
+
+        response = requests.put(request_url, data=data, headers=headers)
+        response_content = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(expected_response, response_content)
+
+
+def create_enrollment(data):
+    """
+    Auxiliary function to setUp test fixtures. Creates/enables a new enrollment.
+
+    :param data: dictionary with all the parameters needed to create an enrollment.
+    """
+    req_data = {
+        "email": data["site1_data"]["user_email"],
+        "course_id": data["site1_data"]["course"]["id"],
+        "mode": data["site1_data"]["course"]["mode"],
+    }
+    headers = {
+        "Authorization": "Bearer {}".format(data["site1_data"]["token"]),
+        "Host": data["site1_data"]["host"],
+    }
+    request_url = "{}/{}".format(data["site1_data"]["base_url"], data["endpoint"])
+    response = requests.post(request_url, data=req_data, headers=headers)
+    response.raise_for_status()
+
+
+def delete_enrollment(data):
+    """
+    Auxiliary function to setUp test fixtures. Deletes an enrollment if exists.
+
+    :param data: dictionary with all the parameters needed to delete an enrollment.
+    """
+    req_data = {
+        "email": data["site1_data"]["user_email"],
+        "course_id": data["site1_data"]["course"]["id"],
+    }
+    headers = {
+        "Authorization": "Bearer {}".format(data["site1_data"]["token"]),
+        "Host": data["site1_data"]["host"],
+    }
+    request_url = "{}/{}".format(data["site1_data"]["base_url"], data["endpoint"])
+    response = requests.delete(request_url, data=req_data, headers=headers)
+    if response.status_code == 404:
+        return
+    response.raise_for_status()


### PR DESCRIPTION
In addition to the unit tests that were already present with this PR it will now be possible to test al CRUD operations against a production, staging or local server. The suite uses a `test_data` file to handle the configuration of the tests. Make sure to edit this file depending on what you are wanting to do. A README with detailed instructions on how to run the tests is also included.