### PR TITLE
Add swagger support for documentation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Change Log
 Unreleased
 ----------
 
+* Add swagger support
+* Improve internal documentation
+
 [3.4.0] - 2020-12-16
 --------------------
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -4,6 +4,8 @@ API v1 serializers.
 # pylint: disable=abstract-method
 from __future__ import absolute_import, unicode_literals
 
+from collections import OrderedDict
+
 from django.conf import settings
 from rest_framework import serializers
 
@@ -171,8 +173,24 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=USERNAME_MAX_LENGTH, default=None, source='user')
     is_active = serializers.BooleanField(default=True)
     mode = serializers.CharField(max_length=100)
-    enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, default=[])
+    enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, required=False)
     course_id = EdxappValidatedCourseIDField()
+
+    class Meta:
+        """
+        Add extra details for swagger
+        """
+        swagger_schema_fields = {
+            "example": OrderedDict(
+                [
+                    ("username", "johndoe"),
+                    ("is_active", True),
+                    ("mode", "audit"),
+                    ("enrollment_attributes", []),
+                    ("course_id", "course-v1:edX+DemoX+Demo_Course")
+                ]
+            ),
+        }
 
     def validate(self, attrs):
         """

--- a/eox_core/api_schema.py
+++ b/eox_core/api_schema.py
@@ -1,0 +1,58 @@
+"""
+Swagger view generator
+"""
+from django.conf import settings
+from django.conf.urls import url
+from drf_yasg.generators import OpenAPISchemaGenerator
+from drf_yasg.openapi import SwaggerDict
+from drf_yasg.views import get_schema_view
+from edx_api_doc_tools import get_docs_cache_timeout, make_api_info
+from rest_framework import permissions
+
+from eox_core.api.v1 import views
+
+
+class APISchemaGenerator(OpenAPISchemaGenerator):
+    """
+    Schema generator for eox-core.
+
+    Define an exclusive base path to perform requests for each endpoint and a
+    specific security definition using oauth without overwritting project wide
+    settings.
+    """
+
+    def get_schema(self, request=None, public=False):
+        schema = super().get_schema(request, public)
+        schema.base_path = '/eox-core/api/v1/'
+        return schema
+
+    def get_security_definitions(self):
+        security_definitions = {
+            'OAuth2': {
+                'flow': 'application',
+                'tokenUrl': '{}/oauth2/access_token/'.format(settings.LMS_ROOT_URL),
+                'type': 'oauth2',
+            },
+        }
+        security_definitions = SwaggerDict.as_odict(security_definitions)
+        return security_definitions
+
+
+api_urls = [  # pylint: disable=invalid-name
+    url(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
+]
+
+api_info = make_api_info(  # pylint: disable=invalid-name
+    title="eox core",
+    version="v1",
+    email=" contact@edunext.co",
+    description="REST APIs to interact with edxapp",
+)
+
+docs_ui_view = get_schema_view(  # pylint: disable=invalid-name
+    api_info,
+    generator_class=APISchemaGenerator,
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+    patterns=api_urls,
+).with_ui('swagger', cache_timeout=get_docs_cache_timeout())

--- a/eox_core/urls.py
+++ b/eox_core/urls.py
@@ -3,6 +3,7 @@
 from django.conf.urls import include, url
 
 from eox_core import views
+from eox_core.api_schema import docs_ui_view
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
@@ -11,4 +12,5 @@ urlpatterns = [  # pylint: disable=invalid-name
     url(r'^api/', include('eox_core.api.urls', namespace='eox-api')),
     url(r'^data-api/', include('eox_core.api.data.v1.urls', namespace='eox-data-api')),
     url(r'^management/', include('eox_core.cms.urls', namespace='eox-course-management')),
+    url(r'^api-docs/$', docs_ui_view, name='apidocs-ui'),
 ]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,6 @@ django-filter
 django-oauth-toolkit
 django-oauth2-provider
 django-waffle
+edx-api-doc-tools>=1.4.0
 edx-proctoring
 edx-opaque-keys[django]
-edx-api-doc-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,6 +24,7 @@ billiard==3.3.0.23
     # via
     #   -r requirements/base.txt
     #   celery
+celery==3.1.26.post2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -52,6 +53,7 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-proctoring
+django-filter==2.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -59,16 +61,19 @@ django-ipware==3.0.2
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
+django-model-utils==4.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-proctoring
     #   edx-when
+django-oauth-toolkit==1.3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
 django-oauth2-provider==0.2.6.1
     # via -r requirements/base.txt
+django-waffle==0.18.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -79,6 +84,7 @@ django-webpack-loader==0.7.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
+django==2.2.17
     # via
     #   -r requirements/base.txt
     #   django-crum
@@ -96,6 +102,7 @@ django-webpack-loader==0.7.0
     #   event-tracking
     #   jsonfield2
     #   rest-condition
+djangorestframework==3.9.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -121,6 +128,7 @@ edx-django-utils==3.13.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-when
+edx-drf-extensions==6.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -133,6 +141,7 @@ edx-opaque-keys[django]==2.1.0
     #   edx-drf-extensions
     #   edx-proctoring
     #   edx-when
+edx-proctoring==2.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt


### PR DESCRIPTION
The current documentation is no easily discoverable, with this PR with can make our documentation public and of easy access from any site that uses eox-core. The main benefits are:

1. Live documentation, can perform interactive requests.
2. Swagger it's [already](https://github.com/edx/edx-platform/pull/21207) on the platform.
3. Can be used to produce static documentation.

(2021/01/11 edit): Some test requirements were not correctly upgraded on #126, so I also added them.