### PR TITLE
feat(tpa): create pipeline step to ensure creation of users with usable password

### DIFF
--- a/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
@@ -82,3 +82,8 @@ def get_user_profile():
     except ImportError:
         UserProfile = object
     return UserProfile
+
+
+def generate_password(*args, **kwargs):
+    """ Generates a password """
+    return "ThisShouldBeARandomPassword"

--- a/eox_core/edxapp_wrapper/backends/users_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_j_v1.py
@@ -15,6 +15,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_api.accounts import USERNAME_MAX_LENGTH  # pylint: disable=import-error,unused-import
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer  # pylint: disable=import-error
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api  # pylint: disable=import-error
+from openedx.core.djangoapps.user_authn.utils import generate_password  # pylint: disable=import-error,unused-import
 from openedx.core.djangoapps.user_authn.views.registration_form import (  # pylint: disable=import-error
     AccountCreationForm,
 )

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -86,3 +86,13 @@ def get_username_max_length():
     backend_function = settings.EOX_CORE_USERS_BACKEND
     backend = import_module(backend_function)
     return backend.USERNAME_MAX_LENGTH
+
+
+def generate_password(*args, **kwargs):
+    """
+    Runs the generate_password funcion of edx-platform used to generate
+     a random password.
+    """
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+    return backend.generate_password(*args, **kwargs)


### PR DESCRIPTION
At the creation of new users through some TPA providers, some of them are created with an unusable password, a user with an unusable password cannot login if the common.djangoapps.third_party.pipeline.set_logged_in_cookies step is enabled.

This new pipeline step will prevent that from happening since all the users created in the auth pipeline will have an usable password.
