### PR TITLE
Add user attribute record for auto_password_via_tpa_pipeline

### DIFF
--- a/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
+++ b/eox_core/edxapp_wrapper/backends/users_h_v1_test.py
@@ -87,3 +87,14 @@ def get_user_profile():
 def generate_password(*args, **kwargs):
     """ Generates a password """
     return "ThisShouldBeARandomPassword"
+
+
+def get_user_attribute():
+    """
+    Get test UserAttribute model
+    """
+    try:
+        from student.models import UserAttribute  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        UserAttribute = object
+    return UserAttribute

--- a/eox_core/edxapp_wrapper/backends/users_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_j_v1.py
@@ -245,3 +245,8 @@ def get_user_profile():
     """ Gets the UserProfile model """
 
     return UserProfile
+
+
+def get_user_attribute():
+    """ Gets the UserAttribute model """
+    return UserAttribute

--- a/eox_core/edxapp_wrapper/users.py
+++ b/eox_core/edxapp_wrapper/users.py
@@ -96,3 +96,11 @@ def generate_password(*args, **kwargs):
     backend_function = settings.EOX_CORE_USERS_BACKEND
     backend = import_module(backend_function)
     return backend.generate_password(*args, **kwargs)
+
+
+def get_user_attribute():
+    """ Gets the UserAttribute model """
+    backend_function = settings.EOX_CORE_USERS_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_user_attribute()

--- a/eox_core/pipeline.py
+++ b/eox_core/pipeline.py
@@ -5,7 +5,7 @@ import logging
 
 from django.db.models.signals import post_save
 
-from eox_core.edxapp_wrapper.users import generate_password, get_user_profile
+from eox_core.edxapp_wrapper.users import generate_password, get_user_attribute, get_user_profile
 from eox_core.logging import logging_pipeline_step
 
 try:
@@ -33,6 +33,10 @@ def ensure_new_user_has_usable_password(backend, user=None, **kwargs):
     if user and is_new and not user.has_usable_password():
         user.set_password(generate_password(length=25))
         user.save()
+
+        user_attribute_model = get_user_attribute()
+        user_attribute_model.set_user_attribute(user, 'auto_password_via_tpa_pipeline', 'true')
+
         logging_pipeline_step(
             "info",
             "Assigned an usable password to the user on creation.",

--- a/eox_core/tests/test_pipeline.py
+++ b/eox_core/tests/test_pipeline.py
@@ -22,13 +22,17 @@ class EnsureUserPasswordUsableTest(TestCase):
         self.backend_mock = MagicMock()
         self.user_mock = MagicMock(spec=User)
 
-    def test_new_user_gets_usable_password(self):
+    @patch('eox_core.pipeline.get_user_attribute')
+    def test_new_user_gets_usable_password(self, get_user_attribute_mock):
         """
         A new user with an unusable password will get a new password.
         """
+        user_attribute_mock = MagicMock()
+        get_user_attribute_mock.return_value = user_attribute_mock
         self.user_mock.has_usable_password.return_value = False
         ensure_new_user_has_usable_password(self.backend_mock, user=self.user_mock, is_new=True)
         self.user_mock.save.assert_called()
+        user_attribute_mock.set_user_attribute.assert_called()
 
     def test_new_user_already_with_usable_password(self):
         """


### PR DESCRIPTION
In this PR we are adding an UserAttribute record to indicate that a password was generated to a user on creation.