### PR TITLE
feat: add apiview to get users cohort

### DIFF
--- a/eox_core/api/v1/tests/test_cohort.py
+++ b/eox_core/api/v1/tests/test_cohort.py
@@ -1,0 +1,99 @@
+"""
+Test module for the User Cohort API.
+"""
+from django.contrib.auth.models import User
+from django.urls import reverse
+from mock import MagicMock, patch
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class TestUserCohortAPI(APITestCase):
+    """Tests class fort UserCohort API endpoints."""
+
+    def setUp(self):
+        """Setup method for test class."""
+        self.api_user = User(1, "api_user@example.com", "api_user")
+        self.test_user = User(2, "test@example.com", "test")
+        self.client.force_authenticate(user=self.api_user)  # pylint: disable=no-member
+        self.url = reverse("eox-api:eox-api:edxapp-cohort")
+        self.test_user_cohort = MagicMock()
+        self.test_user_cohort.name = "Team 1"
+        self.api_user_cohort = MagicMock()
+        self.api_user_cohort.name = "Team 2"
+
+    @patch("eox_core.api.v1.views.get_user_cohort")
+    @patch("eox_core.api.v1.views.get_valid_course_key")
+    @patch("eox_core.api.v1.views.get_edxapp_user")
+    def test_get_cohort_name(self, get_user_mock, _, get_cohort_mock):
+        """
+        Used to test that the users cohort name can be retrieved given a course and a username.
+        """
+        query_params = {
+            "username": "test",
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+        }
+        get_user_mock.return_value = self.api_user
+        get_cohort_mock.return_value = self.test_user_cohort
+        expected_response = {
+            "cohort_name": self.test_user_cohort.name,
+        }
+
+        response = self.client.get(self.url, query_params)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected_response)
+
+    @patch("eox_core.api.v1.views.get_user_cohort")
+    @patch("eox_core.api.v1.views.get_valid_course_key")
+    @patch("eox_core.api.v1.views.get_edxapp_user")
+    def test_user_without_cohort(self, get_user_mock, _, get_cohort_mock):
+        """
+        Used to test getting the name of a cohort with a user without cohort.
+        """
+        query_params = {
+            "username": "test",
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+        }
+        get_user_mock.return_value = self.api_user
+        get_cohort_mock.return_value = None
+
+        response = self.client.get(self.url, query_params)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("eox_core.api.v1.views.get_user_cohort")
+    @patch("eox_core.api.v1.views.get_valid_course_key")
+    @patch("eox_core.api.v1.views.get_edxapp_user")
+    def test_get_cohort_without_username(self, get_user_mock, _, get_cohort_mock):
+        """
+        Used to test getting the name of a cohort without username param.
+        """
+        query_params = {
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+        }
+        get_cohort_mock.return_value = self.api_user_cohort
+        expected_response = {
+            "cohort_name": self.api_user_cohort.name,
+        }
+
+        response = self.client.get(self.url, query_params)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected_response)
+
+    @patch("eox_core.api.v1.views.get_user_cohort")
+    @patch("eox_core.api.v1.views.get_valid_course_key")
+    @patch("eox_core.api.v1.views.get_edxapp_user")
+    def test_get_cohort_without_course_id(self, get_user_mock, _, get_cohort_mock):
+        """
+        Used to test getting the name of a cohort without course_id param.
+        """
+        query_params = {
+            "username": "test",
+        }
+        get_user_mock.return_value = self.api_user
+
+        response = self.client.get(self.url, query_params)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/eox_core/api/v1/urls.py
+++ b/eox_core/api/v1/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [  # pylint: disable=invalid-name
     url(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
     url(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
     url(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
+    url(r'^cohort/$', views.EdxappUserCohort.as_view(), name='edxapp-cohort'),
     url(r'^pre-enrollment/$', views.EdxappPreEnrollment.as_view(), name='edxapp-pre-enrollment'),
     url(r'^userinfo/$', views.UserInfo.as_view(), name='edxapp-userinfo'),
 ]

--- a/eox_core/api_schema.py
+++ b/eox_core/api_schema.py
@@ -41,6 +41,7 @@ class APISchemaGenerator(OpenAPISchemaGenerator):
 api_urls = [  # pylint: disable=invalid-name
     url(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
     url(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
+    url(r'^cohort/$', views.EdxappUserCohort.as_view(), name='edxapp-cohort'),
 ]
 
 api_info = make_api_info(  # pylint: disable=invalid-name

--- a/eox_core/edxapp_wrapper/backends/cohorts_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/cohorts_j_v1.py
@@ -1,0 +1,11 @@
+"""
+Backend for the Cohorts that works under the open-release/juniper.master tag.
+"""
+from openedx.core.djangoapps.course_groups.cohorts import get_cohort  # pylint: disable=import-error
+
+
+def get_user_cohort(*args, **kwargs):
+    """
+    Function used to get CourseUserGroup (cohort type) for a given course and user.
+    """
+    return get_cohort(*args, **kwargs)

--- a/eox_core/edxapp_wrapper/cohorts.py
+++ b/eox_core/edxapp_wrapper/cohorts.py
@@ -1,0 +1,15 @@
+"""
+Users public function definitions
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+
+def get_user_cohort(*args, **kwargs):
+    """ Creates the edxapp user """
+
+    backend_function = settings.EOX_CORE_USER_COHORT_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_user_cohort(*args, **kwargs)

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -24,6 +24,7 @@ def plugin_settings(settings):
     settings.EOX_CORE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.enrollment_h_v1"
     settings.EOX_CORE_PRE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.pre_enrollment_h_v1"
     settings.EOX_CORE_CERTIFICATES_BACKEND = "eox_core.edxapp_wrapper.backends.certificates_h_v1"
+    settings.EOX_CORE_USER_COHORT_BACKEND = "eox_core.edxapp_wrapper.backends.cohorts_j_v1"
     settings.EOX_CORE_CONFIGURATION_HELPER_BACKEND = "eox_core.edxapp_wrapper.backends.configuration_helpers_h_v1"
     settings.EOX_CORE_COURSEWARE_BACKEND = "eox_core.edxapp_wrapper.backends.courseware_h_v1"
     settings.EOX_CORE_GRADES_BACKEND = "eox_core.edxapp_wrapper.backends.grades_h_v1"


### PR DESCRIPTION
**Description**

This PR adds a new APIView that uses methods from edx-platform to get the name of a cohort given a course_id and a username. 

**Motivation**

https://3.basecamp.com/3966315/buckets/8050706/todos/3608713852

Before making this PR other alternatives were considered but they didn't fit our use case:

1. [CohortHandler](https://github.com/eduNEXT/edunext-platform/blob/e86e50ffe7b0d596396e27eff3897811d4e63802/openedx/core/djangoapps/course_groups/views.py#L479): 
   GET /api/cohorts/v1/courses/{course_id}/cohorts 
In this case all cohorts will be returned.
2. [CohortUsers](https://github.com/eduNEXT/edunext-platform/blob/e86e50ffe7b0d596396e27eff3897811d4e63802/openedx/core/djangoapps/course_groups/views.py#L574):
   GET /api/cohorts/v1/courses/{course_id}/cohorts/{cohort_id}/users
 In this case we'll get all users associated with a specified cohort.

Perhaps, we could modify CohortUsers to accept the username, and thus check if the user belongs to cohort X.

Donwfalls:

- Although this modification is simple, we would still have to get all cohorts to check one by one if the user belongs to that one.

- Too many requests?

Then this alternative was a better fit.