### PR TITLE
fix: add USERNAME_MAX_LENGTH not used import

### DIFF
--- a/eox_core/edxapp_wrapper/backends/users_l_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_l_v1.py
@@ -26,6 +26,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY  # pylint: disable=import-error
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers  # pylint: disable=import-error
+from openedx.core.djangoapps.user_api.accounts import USERNAME_MAX_LENGTH  # pylint: disable=import-error,unused-import
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer  # pylint: disable=import-error
 from openedx.core.djangoapps.user_api.accounts.views import \
     _set_unusable_password  # pylint: disable=import-error,unused-import


### PR DESCRIPTION
This import is used by the users wrapper and gave this error:
```
  File "/edx/src/edxapp/eox-core/eox_core/edxapp_wrapper/users.py", line 97, in get_username_max_length
    return backend.USERNAME_MAX_LENGTH
AttributeError: module 'eox_core.edxapp_wrapper.backends.users_l_v1' has no attribute 'USERNAME_MAX_LENGTH'
```
