### PR TITLE
fix: fix cache issue with ConfigurableOpenIdConnectAuth backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+* Add method override in ConfigurableOpenIdConnectAuth to avoid getting per class
+  config.
 
 [4.10.0] - 2021-05-28
 --------------------

--- a/eox_core/social_tpa_backends.py
+++ b/eox_core/social_tpa_backends.py
@@ -37,3 +37,17 @@ class ConfigurableOpenIdConnectAuth(OpenIdConnectAuth):
                 LOG.error("Tried and failed to set property %s of a config-based-openidconnect", key)
 
         super(ConfigurableOpenIdConnectAuth, self).__init__(*args, **kwargs)
+
+    def oidc_config(self):
+        """
+        Override method that gets OICD configuration per class instance.
+        """
+        LOG.debug(
+            "Be aware that ConfigurableOpenIdConnectAuth is using an override "
+            "method to get OICD configuration."
+        )
+        if not hasattr(self, 'configuration'):
+            self.configuration = self.get_json(  # pylint: disable=attribute-defined-outside-init
+                self.OIDC_ENDPOINT + '/.well-known/openid-configuration'
+            )
+        return self.configuration


### PR DESCRIPTION
This PR overrides a method from OpenIdConnect backend to allow us getting OIDC configuration per instance instead of per class