### PR TITLE
feat: add override extra_data method to OIDC

### DIFF
--- a/eox_core/social_tpa_backends.py
+++ b/eox_core/social_tpa_backends.py
@@ -51,3 +51,13 @@ class ConfigurableOpenIdConnectAuth(OpenIdConnectAuth):
                 self.OIDC_ENDPOINT + '/.well-known/openid-configuration'
             )
         return self.configuration
+
+    def extra_data(self, user, uid, response, details=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
+        """
+        Override method extra_data returned by the provider including user
+        information.
+        """
+        data = super().extra_data(user, uid, response, details, *args, **kwargs)
+        data["user_details"] = self.get_user_details(response)
+
+        return data


### PR DESCRIPTION
### Description
This PR adds an override method to the OIDC custom backend. The method adds useful information to the extra_data field from the UserSocialAuth model.

### How to test
1. OIDC configuration
2. There's a pipeline step called `load_extra_data` that sets the new info every time the OIDC pipeline is executed (eg. when login in). This pipeline step belongs to the `DEFAULT_AUTH_PIPELINE`. So, log in to the site using the OIDC provider

Check extra_data and you'll get:
![2021-06-24_09-01](https://user-images.githubusercontent.com/64440265/123267336-e4ada680-d4ca-11eb-9d27-aa218a215f8d.png)

More context: https://3.basecamp.com/3966315/buckets/8050706/todos/3834823891