### PR TITLE
refactor: add debug mode when loading extra_data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 ~~~~~~~
 * Override the ``get_user_id`` method from ``ConfigurableOpenIdConnectAuth`` to
   include a slug before the uid.
+* Add debug mode option to extra_data method from the ConfigurableOpenIdConnectAuth backend.
 
 [4.11.0] - 2021-06-24
 ---------------------


### PR DESCRIPTION
This PR adds debug mode when loading extra_data during the Auth pipeline execution. It also wraps get_user_details in try-except which allows saving information even when failing.