### PR TITLE
fix: pin edx-api-doc-tools. 1.4.3 isn't compatible with python3.5

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,6 @@ django-filter
 django-oauth-toolkit
 django-oauth2-provider
 django-waffle
-edx-api-doc-tools>=1.4.0
+edx-api-doc-tools==1.4.0
 edx-proctoring
 edx-opaque-keys[django]


### PR DESCRIPTION
# Description

The new release of api-doc-tools breaks python3.5