### PR TITLE
fix: EdxappExtendedUserSerializer to include all  "EDNX_CUSTOM_REGISTRATION_FIELDS"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[4.13.2] - 2021-07-16
+---------------------
+
+Changed
+~~~~~~~
+* EdxappExtendedUserSerializer to include all the custom registration fields.
+
 [4.13.1] - 2021-07-15
 ---------------------
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -152,7 +152,7 @@ class EdxappExtendedUserSerializer(EdxappUserSerializer):
             field_name = custom_field.get("name")
             field_type = custom_field.get("type")
 
-            if field_name in extended_profile_fields and field_type in ALLOWED_TYPES:
+            if field_type in ALLOWED_TYPES:
                 serializer_field = {}
 
                 serializer_field["required"] = extra_fields.get(field_name) == "required"


### PR DESCRIPTION
Currently, the EdxappExtendedUserSerializer includes only the EDNX_CUSTOM_REGISTRATION_FIELDS that are also in the setting  "extended_profile_fields"