### PR TITLE
feat: send signal after user registration through API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+Send post_register signal after user registration through API call.
 
 [4.13.2] - 2021-07-16
 ---------------------

--- a/eox_core/edxapp_wrapper/backends/users_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_j_v1.py
@@ -39,6 +39,14 @@ from student.models import (
     username_exists_or_retired,
 )
 
+# pylint: disable=ungrouped-imports
+try:
+    from openedx.core.lib.triggers.v1 import post_register
+except ImportError:
+    # In case edx-platform -vanilla- Juniper release is used
+    from openedx.core.djangoapps.user_authn.views.register import REGISTER_USER as post_register
+
+
 LOG = logging.getLogger(__name__)
 User = get_user_model()  # pylint: disable=invalid-name
 
@@ -151,6 +159,9 @@ def create_edxapp_user(*args, **kwargs):
         errors.append("No comments_service_user was created")
 
     # TODO: link account with third party auth
+
+    # Announce registration through API call
+    post_register.send_robust(sender=None, user=user)  # pylint: disable=no-member
 
     lang_pref = kwargs.pop("language_preference", False)
     if lang_pref:


### PR DESCRIPTION
PR #162 was closed in favor of this one.

This PR sends a signal after the user registration through `POST /eox-core/api/v1/user/`.  The signal is placed in a similar location as when registering through the LMS `/register` page, here is the reference: https://github.com/eduNEXT/edunext-platform/pull/510. It uses a backend to import the signal.

Context: https://3.basecamp.com/3966315/buckets/8050706/todos/3933592446