### PR TITLE
fix: wrap openedx imports in try-except block to avoid import errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+Changed
+~~~~~~~
+* Wrap course edxapp imports with try-except block.
 
 [4.14.0] - 2021-07-20
 ---------------------

--- a/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/coursekey_h_v1.py
@@ -9,8 +9,12 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.site_configuration.helpers import get_all_orgs, get_current_site_orgs
 from rest_framework.serializers import ValidationError
+
+try:
+    from openedx.core.djangoapps.site_configuration.helpers import get_all_orgs, get_current_site_orgs
+except ImportError:
+    get_all_orgs, get_current_site_orgs = object, object  # pylint: disable=invalid-name
 
 
 def get_valid_course_key(course_id):

--- a/eox_core/edxapp_wrapper/backends/courses_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/courses_h_v1.py
@@ -1,13 +1,19 @@
 """
 Backend for contenstore courses.
 """
-
-from contentstore.views.course import (  # pylint: disable=import-error
-    _process_courses_list,
-    get_courses_accessible_to_user,
-)
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-error
-from openedx.core.djangoapps.models.course_details import CourseDetails  # pylint: disable=import-error
+try:
+    from contentstore.views.course import (  # pylint: disable=import-error
+        _process_courses_list,
+        get_courses_accessible_to_user,
+    )
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-error
+    from openedx.core.djangoapps.models.course_details import CourseDetails  # pylint: disable=import-error
+except ImportError:
+    # pylint: disable=invalid-name
+    _process_courses_list = object
+    get_courses_accessible_to_user = object
+    CourseOverview = object
+    CourseDetails = object
 
 
 def courses_accessible_to_user(*args, **kwargs):


### PR DESCRIPTION
**Description**

This PR wraps course and coursekey backends in a try-except block to avoid import errors when executing tests in other packages

