### PR TITLE
docs: add enrollment force doc and change serializer for response doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[4.15.1] - 2021-08-13
+---------------------
+
+Changed
+~~~~~~~
+* Add force flag to post method of enrollments api
+* Update serializers used by enrollments api
+
 [4.15.0] - 2021-08-06
 ---------------------
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -318,6 +318,15 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, required=False)
     course_id = EdxappValidatedCourseIDField()
 
+    def validate(self, attrs):
+        """
+        Check that there are no issues with enrollment
+        """
+        errors = check_edxapp_enrollment_is_valid(**attrs)
+        if errors:
+            raise serializers.ValidationError(", ".join(errors))
+        return attrs
+
     class Meta:
         """
         Add extra details for swagger
@@ -329,19 +338,10 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
                     ("is_active", True),
                     ("mode", "audit"),
                     ("enrollment_attributes", []),
-                    ("course_id", "course-v1:edX+DemoX+Demo_Course")
-                ]
+                    ("course_id", "course-v1:edX+DemoX+Demo_Course"),
+                ],
             ),
         }
-
-    def validate(self, attrs):
-        """
-        Check that there are no issues with enrollment
-        """
-        errors = check_edxapp_enrollment_is_valid(**attrs)
-        if errors:
-            raise serializers.ValidationError(", ".join(errors))
-        return attrs
 
 
 class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
@@ -354,6 +354,19 @@ class EdxappCourseEnrollmentQuerySerializer(EdxappCourseEnrollmentSerializer):
     force = serializers.BooleanField(default=False)
     course_id = EdxappValidatedCourseIDField(default=None)
     bundle_id = serializers.CharField(max_length=255, default=None)
+
+    class Meta(EdxappCourseEnrollmentSerializer.Meta):
+        """
+        Add extra details for swagger
+        """
+        swagger_schema_fields = {
+            "example": OrderedDict(
+                {
+                    "force": False,
+                    **EdxappCourseEnrollmentSerializer.Meta.swagger_schema_fields.get("example")
+                },
+            ),
+        }
 
 
 class EdxappCoursePreEnrollmentSerializer(EdxappWithWarningSerializer):

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -534,9 +534,9 @@ class EdxappEnrollment(UserQueryMixin, APIView):
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     @apidocs.schema(
-        body=EdxappCourseEnrollmentSerializer,
+        body=EdxappCourseEnrollmentQuerySerializer,
         responses={
-            200: EdxappCourseEnrollmentSerializer,
+            200: EdxappCourseEnrollmentQuerySerializer,
             202: "User doesn't belong to site.",
             400: "Bad request, invalid course_id or missing either email or username.",
         },
@@ -554,6 +554,7 @@ class EdxappEnrollment(UserQueryMixin, APIView):
               "username": "johndoe",
               "course_id": "course-v1:edX+DemoX+Demo_Course",
               "mode": "audit",
+              "force": "False",
               "is_active": "False",
               "enrollment_attributes": [
                 {
@@ -581,6 +582,11 @@ class EdxappEnrollment(UserQueryMixin, APIView):
         - `is_active` (boolean, _body_):
             Flag indicating whether the enrollment is active.
 
+        - `force` (boolean, _body_):
+            Flag indicating whether the platform business rules for enrollment must be skipped. When it is true, the enrollment
+            is created without looking at the enrollment dates, if the course is full, if the enrollment mode is part of the modes
+            allowed by that course and other course settings.
+
         - `enrollment_attributes` (list, _body_):
             List of enrollment attributes. An enrollment attribute can be used to add extra parameters for a specific course mode.
             It must be a dictionary containing the following:
@@ -597,6 +603,7 @@ class EdxappEnrollment(UserQueryMixin, APIView):
               "course_id": "course-v1:edX+DemoX+Demo_Course",
               "mode": "audit",
               "is_active": "False",
+              "force": "False",
               "enrollment_attributes": [
                 {
                   "namespace": "credit",
@@ -610,6 +617,7 @@ class EdxappEnrollment(UserQueryMixin, APIView):
               "course_id": "course-v1:edX+DemoX+Demo_Course",
               "mode": "audit",
               "is_active": "True",
+              "force": "False",
               "enrollment_attributes": []
              },
             ]
@@ -626,9 +634,9 @@ class EdxappEnrollment(UserQueryMixin, APIView):
         )
 
     @apidocs.schema(
-        body=EdxappCourseEnrollmentSerializer,
+        body=EdxappCourseEnrollmentQuerySerializer,
         responses={
-            200: EdxappCourseEnrollmentSerializer,
+            200: EdxappCourseEnrollmentQuerySerializer,
             202: "User or enrollment doesn't belong to site.",
             400: "Bad request, invalid course_id or missing either email or username.",
         },


### PR DESCRIPTION
Documentation changes:

1. I added information about the enrollment force flag
2. Add force to EdxappCourseEnrollmentQuerySerializer
3. Use EdxappCourseEnrollmentQuerySerializer in `post` docs 

### About force
I got the information about the `force` by comparing the behavior of the two functions `_force_create_enrollment `and `_create_or_update_enrollment` in `eox-core/eox_core/edxapp_wrapper/backends/enrollment_h_v1.py`. This last function raises several exceptions such as:
EnrollmentClosedError
CourseFullError
AlreadyEnrolledError
and it also verifies that the enrollment mode belongs to the modes allowed by the course, while the force function skips them.