### PR TITLE
feat(TPA): Add middleware to handle TPA exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+* Add new middleware to catch unhandled exceptions during the third
+  party authentication.
 
 [4.15.1] - 2021-08-13
 ---------------------

--- a/eox_core/edxapp_wrapper/backends/third_party_auth_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/third_party_auth_j_v1.py
@@ -1,0 +1,10 @@
+"""Backend for the third party authentication exception middleware."""
+
+
+def get_tpa_exception_middleware():
+    """Get the ExceptionMiddleware class."""
+    try:
+        from third_party_auth.middleware import ExceptionMiddleware  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        from django.utils.deprecation import MiddlewareMixin as ExceptionMiddleware  # pylint: disable=import-outside-toplevel
+    return ExceptionMiddleware

--- a/eox_core/edxapp_wrapper/third_party_auth.py
+++ b/eox_core/edxapp_wrapper/third_party_auth.py
@@ -1,0 +1,14 @@
+"""
+Third Party Auth Exception Middleware definitions.
+"""
+
+from importlib import import_module
+
+from django.conf import settings
+
+
+def get_tpa_exception_middleware():
+    """Get the ExceptionMiddleware class."""
+    backend_function = settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND
+    backend = import_module(backend_function)
+    return backend.get_tpa_exception_middleware()

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -49,6 +49,7 @@ def plugin_settings(settings):
     settings.EOX_CORE_USER_UPDATE_SAFE_FIELDS = ["is_active", "password", "fullname", "mailing_address", "year_of_birth", "gender", "level_of_education", "city", "country", "goals", "bio", "phone_number"]
     settings.EOX_CORE_BEARER_AUTHENTICATION = 'eox_core.edxapp_wrapper.backends.bearer_authentication_j_v1'
     settings.EOX_CORE_ASYNC_TASKS = []
+    settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND = 'eox_core.edxapp_wrapper.backends.third_party_auth_j_v1'
 
     if settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
         settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = [

--- a/eox_core/settings/production.py
+++ b/eox_core/settings/production.py
@@ -95,7 +95,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT',
         settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT
     )
-
+    settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_THIRD_PARTY_AUTH_BACKEND',
+        settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND
+    )
     settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = getattr(settings, 'ENV_TOKENS', {}).get(
         'EOX_CORE_USER_ENABLE_MULTI_TENANCY',
         settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY
@@ -119,7 +122,8 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         if settings.EOX_CORE_APPEND_LMS_MIDDLEWARE_CLASSES:
             settings.MIDDLEWARE += [
                 'eox_core.middleware.PathRedirectionMiddleware',
-                'eox_core.middleware.RedirectionsMiddleware'
+                'eox_core.middleware.RedirectionsMiddleware',
+                'eox_core.middleware.TPAExceptionMiddleware'
             ]
 
     # Sentry Integration

--- a/eox_core/settings/test.py
+++ b/eox_core/settings/test.py
@@ -32,6 +32,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.EOX_CORE_ENABLE_UPDATE_USERS = True
     settings.EOX_CORE_USER_UPDATE_SAFE_FIELDS = ["is_active", "password", "fullname"]
     settings.EOX_CORE_BEARER_AUTHENTICATION = 'eox_core.edxapp_wrapper.backends.bearer_authentication_j_v1_test'
+    settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND = 'eox_core.edxapp_wrapper.backends.third_party_auth_j_v1'
 
 
 SETTINGS = SettingsClass()


### PR DESCRIPTION
### Description
During the third party authentication process there are some errors that are not correctly handled and result in a misleading 500 error page. 

As far as we know, this issue happens under any of this three conditions, so far:

1. The connection with the Identity Provider (IdP) results in an HTTP Error. See [social_core/backends/base.py](https://github.com/python-social-auth/social-core/blob/29cbbd22b98d81d569a886b1cc0bd9a316cd124f/social_core/backends/base.py#L237)
2. The pipeline step [`safer_associate_by_email`](https://github.com/eduNEXT/eox-tenant/blob/87906d31fdc3c2012514a9d6fc57a1277f49f6df/eox_tenant/pipeline.py#L15) raises `EoxTenantAuthException` when trying to [associate a staff/admin account ](https://github.com/eduNEXT/eox-tenant/blob/87906d31fdc3c2012514a9d6fc57a1277f49f6df/eox_tenant/pipeline.py#L42) or when an[ account with the same email already exists](https://github.com/eduNEXT/eox-tenant/blob/87906d31fdc3c2012514a9d6fc57a1277f49f6df/eox_tenant/pipeline.py#L36). This is because `EoxTenantAuthException` doesn't inherit from [`SocialAuthBaseException`](https://github.com/python-social-auth/social-core/blob/29cbbd22b98d81d569a886b1cc0bd9a316cd124f/social_core/exceptions.py#L1).
3. If the step `safer_associate_by_email` is not defined in the pipeline a database `IntegrityError` is raised due to conflicting emails.

To solve the issue a new middleware class was created that process this exceptions and passes the correct `AuthException` to the next layer in the middleware chain.

### Testing Instructions

1. To test (1) configure your OIDC provider such as that `OIDC_ENDPOINT` points to the wrong url.
1. To test (2) try to login with an IdP that returns the email of an account with staff/admin access.
1. To test (3) try to login with an IdP that returns the email of an account that already exists without defining `safer_associate_by_email` in the pipeline.

### Aditional details
The error message should look like this:

![http_error](https://user-images.githubusercontent.com/69784365/129757346-bcda1325-7902-426b-9f84-0b4c49ad1bc5.png)

