### PR TITLE
feat: add save_all_parameters and filter_data to eox-audit-model decorators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,16 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+
+[4.16.0] - 2021-08-18
+---------------------
+
+Added
+~~~~~~~
 * Add new middleware to catch unhandled exceptions during the third
   party authentication.
+* Add save_all_parameters argument to the eox-audit-model decorator for the Users API.
+* Add filter_data list to the eox-audit-model decorator for the Enrollments API.
 
 [4.15.1] - 2021-08-13
 ---------------------

--- a/eox_core/api/v1/views.py
+++ b/eox_core/api/v1/views.py
@@ -182,6 +182,7 @@ class EdxappUser(UserQueryMixin, APIView):
             "fullname",
         ],
         hidden_fields=["password"],
+        save_all_parameters=True,
         method_name='eox_core_api_method',
     )
     def post(self, request, *args, **kwargs):
@@ -414,6 +415,7 @@ class EdxappUserUpdater(UserQueryMixin, APIView):
             'is_active',
         ],
         hidden_fields=['password'],
+        save_all_parameters=True,
         method_name='eox_core_api_method',
     )
     def patch(self, request, *args, **kwargs):
@@ -541,7 +543,18 @@ class EdxappEnrollment(UserQueryMixin, APIView):
             400: "Bad request, invalid course_id or missing either email or username.",
         },
     )
-    @audit_drf_api(action='Create single or bulk enrollments', method_name='eox_core_api_method')
+    @audit_drf_api(
+        action='Create single or bulk enrollments',
+        data_filter=[
+            'email',
+            'username',
+            'course_id',
+            'mode',
+            'is_active',
+            'enrollment_attributes',
+        ],
+        method_name='eox_core_api_method',
+    )
     def post(self, request, *args, **kwargs):
         """
         Handle creation of single or bulk enrollments
@@ -641,7 +654,18 @@ class EdxappEnrollment(UserQueryMixin, APIView):
             400: "Bad request, invalid course_id or missing either email or username.",
         },
     )
-    @audit_drf_api(action='Update enrollments on edxapp', method_name='eox_core_api_method')
+    @audit_drf_api(
+        action='Update enrollments on edxapp',
+        data_filter=[
+            'email',
+            'username',
+            'course_id',
+            'mode',
+            'is_active',
+            'enrollment_attributes',
+        ],
+        method_name='eox_core_api_method',
+    )
     def put(self, request, *args, **kwargs):
         """
         Update enrollments on edxapp


### PR DESCRIPTION
This PR adds the save_all_parameters arg to the Users API, also adds the filter_data fields to the enrollments API
For more information about these changes https://github.com/eduNEXT/eox-audit-model/pull/12

**UPDATE**: Everything was successfully tested on stage.