### PR TITLE
Exposing the option to set the deployment environment for Sentry

### DIFF
--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -76,6 +76,7 @@ def plugin_settings(settings):
     # has a match with the regex provided in the exc_text unique element. If exc_text contains more than one
     # regex, the exception is ignored if any of the regex matches the traceback text.
     settings.EOX_CORE_SENTRY_IGNORED_ERRORS = []
+    settings.EOX_CORE_SENTRY_ENVIRONMENT = None
 
     if find_spec('eox_audit_model') and EOX_AUDIT_MODEL_APP not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(EOX_AUDIT_MODEL_APP)

--- a/eox_core/settings/production.py
+++ b/eox_core/settings/production.py
@@ -135,12 +135,17 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_CORE_SENTRY_IGNORED_ERRORS',
         settings.EOX_CORE_SENTRY_IGNORED_ERRORS
     )
+    sentry_environment = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_SENTRY_ENVIRONMENT',
+        settings.EOX_CORE_SENTRY_ENVIRONMENT
+    )
 
     if sentry_sdk is not None and sentry_integration_dsn is not None:
         from eox_core.integrations.sentry import ExceptionFilterSentry  # pylint: disable=import-outside-toplevel
         sentry_sdk.init(
             before_send=ExceptionFilterSentry(),
             dsn=sentry_integration_dsn,
+            environment=sentry_environment,
             integrations=[
                 DjangoIntegration(),
             ],


### PR DESCRIPTION
Sentry allows for setting the `environment` attribute to identify in which stage of deployment an error event occurs. This can help with determining why an error happened and the urgency required to diagnose and resolve an issue.