### PR TITLE
fix: truncate OIDC first_name to field max length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 Unreleased
 ----------
+Changed
+~~~~~~~
+* OIDC get_user_details method truncates user's first_name when exceeds max_length.
 
 [4.16.0] - 2021-08-18
 ---------------------


### PR DESCRIPTION
**Description**
This PR truncates the user's first_name sent by the identity provider to avoid exceeding the Django limit.

**Before**
Error 500:
![image](https://user-images.githubusercontent.com/64440265/134740906-7dab8490-e8e0-45d8-a50f-5b96ab1b7c98.png)

**After**
Registers the user and:
![image](https://user-images.githubusercontent.com/64440265/134740670-dcc8f4e9-59ce-4d99-8ad4-64fb951c1027.png)

The screenshots were taken after testing on stage.