### PR TITLE
fix: avoid failure when first_name is missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Change Log
 Unreleased
 ----------
 
+Changed
+~~~~~~~
+* Avoid failure when getting first_name from OIDC user details.
+
 [4.16.1] - 2021-09-29
 ---------------------
 

--- a/eox_core/social_tpa_backends.py
+++ b/eox_core/social_tpa_backends.py
@@ -63,7 +63,8 @@ class ConfigurableOpenIdConnectAuth(OpenIdConnectAuth):
         """
         user_details = super().get_user_details(response)
         first_name_max_len = User._meta.get_field("first_name").max_length  # pylint: disable=no-member, protected-access
-        user_details["first_name"] = user_details["first_name"][:first_name_max_len]
+        first_name = user_details["first_name"]
+        user_details["first_name"] = first_name[:first_name_max_len] if first_name else first_name
 
         return user_details
 


### PR DESCRIPTION
This PR avoids failure when the first name is not sent by the provider