### PR TITLE
fix: Add 'created' field to EdxappCourseEnrollmentSerializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[4.17.0] - 2021-10-21
+---------------------
+
+Added
+~~~~~~~
+* Date and time of enrolment creation to the Get CourseEnrollment endpoint.
+
 [4.16.2] - 2021-09-30
 ---------------------
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -317,6 +317,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
     mode = serializers.CharField(max_length=100)
     enrollment_attributes = EdxappEnrollmentAttributeSerializer(many=True, required=False)
     course_id = EdxappValidatedCourseIDField()
+    created = serializers.DateTimeField(read_only=True)
 
     def validate(self, attrs):
         """
@@ -339,6 +340,7 @@ class EdxappCourseEnrollmentSerializer(serializers.Serializer):
                     ("mode", "audit"),
                     ("enrollment_attributes", []),
                     ("course_id", "course-v1:edX+DemoX+Demo_Course"),
+                    ("created", "2021-10-11T10:06:17.876505-05:00"),
                 ],
             ),
         }


### PR DESCRIPTION
This PR adds the field _created_ to the EdxappCourseEnrollmentSerializer to expose the creation time and date in the get CourseEnrollment endpoint

Successfully tested in stage