### PR TITLE
fix: Update Users backend for Lilac

### DIFF
--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -24,9 +24,9 @@ def plugin_settings(settings):
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     settings.EOX_CORE_COMMENTS_SERVICE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.comments_service_users_j_v1"
-    settings.EOX_CORE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.users_j_v1"
-    settings.EOX_CORE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.enrollment_h_v1"
-    settings.EOX_CORE_PRE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.pre_enrollment_h_v1"
+    settings.EOX_CORE_USERS_BACKEND = "eox_core.edxapp_wrapper.backends.users_l_v1"
+    settings.EOX_CORE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.enrollment_l_v1"
+    settings.EOX_CORE_PRE_ENROLLMENT_BACKEND = "eox_core.edxapp_wrapper.backends.pre_enrollment_l_v1"
     settings.EOX_CORE_CERTIFICATES_BACKEND = "eox_core.edxapp_wrapper.backends.certificates_h_v1"
     settings.EOX_CORE_CONFIGURATION_HELPER_BACKEND = "eox_core.edxapp_wrapper.backends.configuration_helpers_h_v1"
     settings.EOX_CORE_COURSEWARE_BACKEND = "eox_core.edxapp_wrapper.backends.courseware_h_v1"


### PR DESCRIPTION
After the [support for lilac](https://github.com/eduNEXT/eox-core/pull/143), there were some additions to the Users backend for Juniper. This PR updates the Users backend for Lilac with these changes.

Additions:
- https://github.com/eduNEXT/eox-core/commit/d83d1cbbfa0599585f0dade5532065acbbe16501
- https://github.com/eduNEXT/eox-core/commit/779c2301ef4a88d0d3869c71ad8876fac550f73b

Also, the default backends were changed to the Lilac backends (breaking change)

**Note**: we are going to open a different issue to fix the npm dependencies for python3.8 tests
