### PR TITLE
Add labeler action to github workflows

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: labeler
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: CodelyTV/pr-size-labeler@v1.7.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'true'
+          message_if_xl: >
+            'This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.'
+          github_api_url: 'api.github.com'


### PR DESCRIPTION
## Description
These commits add the labeler action to the GitHub workflows with the purpose of checking one of the steps of the definition of done.

- The PR doesn't have more than 1000 lines.

You can find the Github action repository & documentation here:
https://github.com/CodelyTV/pr-size-labeler