### PR TITLE
ci: add commitlint action to github workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: ['@commitlint/config-angular'],
+  plugins: ['commitlint-plugin-function-rules'],
+  rules: {},
+}


### PR DESCRIPTION
## Description
These commits add the bump version action to the GitHub workflows with the purpose of checking one of the steps of the definition of done.

- The commits on the PR respect the commit convention.

## How to use
### Rules

#### type

  ```
  [
    'build',
    'ci',
    'docs',
    'feat',
    'fix',
    'perf',
    'refactor',
    'revert',
    'style',
    'test'
  ]
  ```

```sh
echo "foo: some message" # fails
echo "fix: some message" # passes
```

#### type-case
  ```
  'lowerCase'
  ```

```sh
echo "FIX: some message" # fails
echo "fix: some message" # passes
```

#### scope-case
```
'lowerCase'
```

```sh
echo "fix(SCOPE): some message" # fails
echo "fix(scope): some message" # passes
```

#### header-max-length
```
72
```

```sh
echo "fix: some message that is way too long and breaks the line max-length by several characters" # fails
echo "fix: some message" # passes
```
More info:
> [Conventional Commits Message - @commitlint/config-angular](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-angular)

You can find how to set the commitlint rules here:
[commitlint-github-action](https://github.com/wagoid/commitlint-github-action)