### PR TITLE
ci: add conditional to run changelog update action

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -28,6 +28,7 @@ jobs:
   update:
     needs: build
     runs-on: ubuntu-latest
+    if: needs.build.outputs.tag
     steps:
       - uses: actions/checkout@v2
       - name: Update Changelog


### PR DESCRIPTION
## Description
This commit fixes the problem with **Changelog Update Action** adding a conditional to run that job only if exists a new tag.

## Issue
- [Bump version #3](https://github.com/eduNEXT/eox-core/actions/runs/1865807381)