### PR TITLE
fix: get settings course_org_filter when validating org for async proc

### DIFF
--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -38,7 +38,7 @@ def plugin_settings(settings):
     settings.DATA_API_DEF_PAGE_SIZE = 1000
     settings.DATA_API_MAX_PAGE_SIZE = 5000
     settings.EOX_CORE_COURSES_BACKEND = "eox_core.edxapp_wrapper.backends.courses_h_v1"
-    settings.EOX_CORE_COURSEKEY_BACKEND = "eox_core.edxapp_wrapper.backends.coursekey_h_v1"
+    settings.EOX_CORE_COURSEKEY_BACKEND = "eox_core.edxapp_wrapper.backends.coursekey_m_v1"
     settings.EOX_CORE_SITE_CONFIGURATION = "eox_core.edxapp_wrapper.backends.site_configuration_h_v1"
     settings.EOX_CORE_COURSE_MANAGEMENT_REQUEST_TIMEOUT = 1000
     settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY = True


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

[get_current_site_orgs()](https://github.com/openedx/edx-platform/blob/open-release/lilac.master/openedx/core/djangoapps/site_configuration/helpers.py#L216) obtains the current site orgs getting first the current site:

![image](https://user-images.githubusercontent.com/64440265/170887657-68e75b65-be1e-4f3c-835f-5927349b15a7.png)
![image](https://user-images.githubusercontent.com/64440265/170887686-02be143e-fa41-4935-a854-63e6be978ad7.png)
![image](https://user-images.githubusercontent.com/64440265/170887699-c80093cf-c6b5-4686-bdb4-9e7837b66d6a.png)
![image](https://user-images.githubusercontent.com/64440265/170887734-6588fb28-2e01-4cbb-9928-195da870af36.png)

 which doesn't exist in async processes. So, this adds an alternative: if the current org is not found then try getting them directly from the site settings.

## Testing instructions

I'm currently testing this with an async task that enrolls users into a course. It's in a private repository, reach out if you want to test it out.

## Additional information

I found this issue while trying to enroll users in a course using an async task and configuring the site with course_org_filter. With this change, it's working correctly.

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->