### PR TITLE
Fix imports in courses_h_v1.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eduNEXT/eox-core/compare/v6.1.1...HEAD)
 
+### Bug Fixes
+
+- fix import for `_process_courses_list` and `get_courses_accessible_to_user`([bb2b333](https://github.com/eduNEXT/eox-core/commit/bb2b333dee382d481bfc7df983cbc62b18a0731a))
+
 Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->

--- a/eox_core/__init__.py
+++ b/eox_core/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for main eox-core app
 """
-__version__ = '6.1.1'
+__version__ = '6.1.2'

--- a/eox_core/edxapp_wrapper/backends/courses_h_v1.py
+++ b/eox_core/edxapp_wrapper/backends/courses_h_v1.py
@@ -2,7 +2,7 @@
 Backend for contenstore courses.
 """
 try:
-    from contentstore.views.course import (  # pylint: disable=import-error
+    from cms.djangoapps.contentstore.views.course import (  # pylint: disable=import-error
         _process_courses_list,
         get_courses_accessible_to_user,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.1.1
+current_version = 6.1.2
 commit = False
 tag = False
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

I've described the issue and the solution in the Issue that I created: [Issue 120](https://github.com/eduNEXT/eox-core/issues/210).

## Testing instructions

I clone this repo and modified the imports in question, then I used this plugin in tutor.


## Additional information

I searched in openedx in `openedx-release/hawthorn.master` branch and the import also shpuld be `cms.djangoapps.contenstore.views.course`.

## Checklist for Merge

- [ ] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->