### PR TITLE
Revert "chore: add openedx_events to requirements."

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,4 +11,3 @@ django-waffle
 edx-api-doc-tools<1.6
 edx-proctoring
 edx-opaque-keys[django]
-openedx-events


### PR DESCRIPTION
Reverts eduNEXT/eox-core#204 for not complying with [OEP 18](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0018-bp-python-dependencies.html)