### PR TITLE
feat: Make extra registration fields optional in during edxapp account creation

### DIFF
--- a/eox_core/edxapp_wrapper/backends/users_j_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_j_v1.py
@@ -3,11 +3,12 @@
 """
 Backend for the create_edxapp_user that works under the open-release/juniper.master tag
 """
-# pylint: disable=import-error
 from __future__ import absolute_import, unicode_literals
 
 import logging
 
+# pylint: disable=import-error
+from crum import get_current_user
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -73,6 +74,37 @@ def check_edxapp_account_conflicts(email, username):
     return conflicts
 
 
+def is_allowed_to_skip_extra_registration_fields(account_creation_data):
+    """
+    Returns True if the conditions are met to skip sending the extra
+    registrations fields durint the account creation.
+
+    Three conditions are checked in order to be able to skip
+    these registration fields:
+    1. The skip_extra_registration_fields field is sent in the data
+        for the account creation as True.
+    2. The user making the request is staff.
+    3. The data received in the parameters does not contain any of the
+        REGISTRATION_EXTRA_FIELDS configured for the microsite.
+
+    In case any of these conditions is not met the function returns
+    False.
+    """
+    skip_extra_registration_fields = account_creation_data.pop("skip_extra_registration_fields", False)
+    current_user = get_current_user()
+    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
+
+    if not (skip_extra_registration_fields and current_user.is_staff):
+        return False
+
+    for field in account_creation_data.keys():
+        if field in extra_fields.keys() or field in extended_profile_fields:
+            return False
+
+    return True
+
+
 class EdnxAccountCreationForm(AccountCreationForm):
     """
     A form to extend the behaviour of the AccountCreationForm.
@@ -123,8 +155,6 @@ def create_edxapp_user(*args, **kwargs):
     """
     errors = []
 
-    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
-    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
     kwargs["name"] = kwargs.pop("fullname", None)
     email = kwargs.get("email")
     username = kwargs.get("username")
@@ -132,19 +162,24 @@ def create_edxapp_user(*args, **kwargs):
     if conflicts:
         return None, [f"Fatal: account collition with the provided: {', '.join(conflicts)}"]
 
+    account_creation_form_data = {
+        "data": kwargs,
+        "tos_required": False,
+        # "enforce_password_policy": enforce_password_policy,
+    }
+
+    # Check if we should send the extra registration fields
+    if not is_allowed_to_skip_extra_registration_fields(kwargs):
+        account_creation_form_data["extra_fields"] = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+        account_creation_form_data["extended_profile_fields"] = getattr(settings, "extended_profile_fields", [])
+
     # Go ahead and create the new user
     with transaction.atomic():
         # In theory is possible to extend the registration form with a custom app
         # An example form app for this can be found at http://github.com/open-craft/custom-form-app
         # form = get_registration_extension_form(data=params)
         # if not form:
-        form = EdnxAccountCreationForm(
-            data=kwargs,
-            tos_required=False,
-            extra_fields=extra_fields,
-            extended_profile_fields=extended_profile_fields,
-            # enforce_password_policy=enforce_password_policy,
-        )
+        form = EdnxAccountCreationForm(**account_creation_form_data)
         (user, profile, registration) = do_create_account(form)  # pylint: disable=unused-variable
 
     site = kwargs.pop("site", False)

--- a/eox_core/edxapp_wrapper/backends/users_l_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_l_v1.py
@@ -21,6 +21,7 @@ from common.djangoapps.student.models import (  # pylint: disable=import-error,n
     get_retired_email_by_email,
     username_exists_or_retired,
 )
+from crum import get_current_user
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -73,6 +74,37 @@ def check_edxapp_account_conflicts(email, username):
     return conflicts
 
 
+def is_allowed_to_skip_extra_registration_fields(account_creation_data):
+    """
+    Returns True if the conditions are met to skip sending the extra
+    registrations fields durint the account creation.
+
+    Three conditions are checked in order to be able to skip
+    these registration fields:
+    1. The skip_extra_registration_fields field is sent in the data
+        for the account creation as True.
+    2. The user making the request is staff.
+    3. The data received in the parameters does not contain any of the
+        REGISTRATION_EXTRA_FIELDS configured for the microsite.
+
+    In case any of these conditions is not met the function returns
+    False.
+    """
+    skip_extra_registration_fields = account_creation_data.pop("skip_extra_registration_fields", False)
+    current_user = get_current_user()
+    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
+
+    if not (skip_extra_registration_fields and current_user.is_staff):
+        return False
+
+    for field in account_creation_data.keys():
+        if field in extra_fields.keys() or field in extended_profile_fields:
+            return False
+
+    return True
+
+
 class EdnxAccountCreationForm(AccountCreationForm):
     """
     A form to extend the behaviour of the AccountCreationForm.
@@ -122,8 +154,6 @@ def create_edxapp_user(*args, **kwargs):
     """
     errors = []
 
-    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
-    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
     kwargs["name"] = kwargs.pop("fullname", None)
     email = kwargs.get("email")
     username = kwargs.get("username")
@@ -131,19 +161,24 @@ def create_edxapp_user(*args, **kwargs):
     if conflicts:
         return None, [f"Fatal: account collition with the provided: {', '.join(conflicts)}"]
 
+    account_creation_form_data = {
+        "data": kwargs,
+        "tos_required": False,
+        # "enforce_password_policy": enforce_password_policy,
+    }
+
+    # Check if we should send the extra registration fields
+    if not is_allowed_to_skip_extra_registration_fields(kwargs):
+        account_creation_form_data["extra_fields"] = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+        account_creation_form_data["extended_profile_fields"] = getattr(settings, "extended_profile_fields", [])
+
     # Go ahead and create the new user
     with transaction.atomic():
         # In theory is possible to extend the registration form with a custom app
         # An example form app for this can be found at http://github.com/open-craft/custom-form-app
         # form = get_registration_extension_form(data=params)
         # if not form:
-        form = EdnxAccountCreationForm(
-            data=kwargs,
-            tos_required=False,
-            extra_fields=extra_fields,
-            extended_profile_fields=extended_profile_fields,
-            # enforce_password_policy=enforce_password_policy,
-        )
+        form = EdnxAccountCreationForm(**account_creation_form_data)
         (user, profile, registration) = do_create_account(form)  # pylint: disable=unused-variable
 
     site = kwargs.pop("site", False)

--- a/eox_core/edxapp_wrapper/backends/users_m_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_m_v1.py
@@ -21,6 +21,7 @@ from common.djangoapps.student.models import (  # pylint: disable=import-error,n
     get_retired_email_by_email,
     username_exists_or_retired,
 )
+from crum import get_current_user
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -73,6 +74,37 @@ def check_edxapp_account_conflicts(email, username):
     return conflicts
 
 
+def is_allowed_to_skip_extra_registration_fields(account_creation_data):
+    """
+    Returns True if the conditions are met to skip sending the extra
+    registrations fields durint the account creation.
+
+    Three conditions are checked in order to be able to skip
+    these registration fields:
+    1. The skip_extra_registration_fields field is sent in the data
+        for the account creation as True.
+    2. The user making the request is staff.
+    3. The data received in the parameters does not contain any of the
+        REGISTRATION_EXTRA_FIELDS configured for the microsite.
+
+    In case any of these conditions is not met then the function returns
+    False.
+    """
+    skip_extra_registration_fields = account_creation_data.pop("skip_extra_registration_fields", False)
+    current_user = get_current_user()
+    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
+
+    if not (skip_extra_registration_fields and current_user.is_staff):
+        return False
+
+    for field in account_creation_data.keys():
+        if field in extra_fields.keys() or field in extended_profile_fields:
+            return False
+
+    return True
+
+
 class EdnxAccountCreationForm(AccountCreationForm):
     """
     A form to extend the behaviour of the AccountCreationForm.
@@ -122,8 +154,6 @@ def create_edxapp_user(*args, **kwargs):
     """
     errors = []
 
-    extra_fields = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
-    extended_profile_fields = getattr(settings, "extended_profile_fields", [])
     kwargs["name"] = kwargs.pop("fullname", None)
     email = kwargs.get("email")
     username = kwargs.get("username")
@@ -131,19 +161,24 @@ def create_edxapp_user(*args, **kwargs):
     if conflicts:
         return None, [f"Fatal: account collition with the provided: {', '.join(conflicts)}"]
 
+    account_creation_form_data = {
+        "data": kwargs,
+        "tos_required": False,
+        # "enforce_password_policy": enforce_password_policy,
+    }
+
+    # Check if we should send the extra registration fields
+    if not is_allowed_to_skip_extra_registration_fields(kwargs):
+        account_creation_form_data["extra_fields"] = getattr(settings, "REGISTRATION_EXTRA_FIELDS", {})
+        account_creation_form_data["extended_profile_fields"] = getattr(settings, "extended_profile_fields", [])
+
     # Go ahead and create the new user
     with transaction.atomic():
         # In theory is possible to extend the registration form with a custom app
         # An example form app for this can be found at http://github.com/open-craft/custom-form-app
         # form = get_registration_extension_form(data=params)
         # if not form:
-        form = EdnxAccountCreationForm(
-            data=kwargs,
-            tos_required=False,
-            extra_fields=extra_fields,
-            extended_profile_fields=extended_profile_fields,
-            # enforce_password_policy=enforce_password_policy,
-        )
+        form = EdnxAccountCreationForm(**account_creation_form_data)
         (user, profile, registration) = do_create_account(form)  # pylint: disable=unused-variable
 
     site = kwargs.pop("site", False)


### PR DESCRIPTION
## Description

In this PR we make some changes to the [create_edxapp_user()](https://github.com/eduNEXT/eox-core/blob/master/eox_core/edxapp_wrapper/backends/users_m_v1.py#L104) in order to make the extra registration fields optional when registering a new user un edxapp.

Three conditions are checked in order to be able to skip these extra registration fields:
    1. The skip_extra_registration_fields field is sent in the data for the account creation as True.
    2. The user making the request is staff.
    3. The data received in the parameters does not contain any of the REGISTRATION_EXTRA_FIELDS configured for the microsite.

In case any of these conditions are not met, the function will request the extra registration fields to be sent for the creation of the new user.

## Why are these changes necessary?

 In PR #223 we are implementing an endpoint that creates a new OAuth Application. 
We need to create a user in the platform to set it as the owner of the new edxapp application and want to use the [create_edxapp_user()](https://github.com/eduNEXT/eox-core/blob/master/eox_core/edxapp_wrapper/backends/users_m_v1.py#L104) function for this. However, this function requires to send the extra registration fields configured for the site during the account creation, so we are making these changes to be able to register a user only with the basic information such as fullname, username and email, without having to worry about other registration fields.

## Testing instructions

The best way to test this change is through the endpoint that creates an Oauth application, implemented in PR #223, since we are not sending any of the extra registration fields during the creation of the user that will be the owner of the application.
On the contrary, if you try to send only these fields
```
{
    "username": "mariecurie",
    "email": "mariecurie@example.com",
    "fullname": "Marie Curie",
}
```
In the endpoint that handles the [creation of a new user](https://openedx.edunext.co/eox-core/api/v1/user/),  you will get form errors for not sending the extra registration fields.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->