### PR TITLE
feat: add endpoint to generate Oauth Application

### DIFF
--- a/eox_core/api/support/v1/serializers.py
+++ b/eox_core/api/support/v1/serializers.py
@@ -5,6 +5,7 @@ Support API v1 serializers.
 from __future__ import absolute_import, unicode_literals
 
 from django.utils import timezone
+from oauth2_provider.models import Application
 from rest_framework import serializers
 
 from eox_core.api.v1.serializers import MAX_SIGNUP_SOURCES_ALLOWED
@@ -63,3 +64,31 @@ class WrittableEdxappUsernameSerializer(serializers.Serializer):
             instance.save()
 
         return instance
+
+
+class OauthApplicationUserSerializer(serializers.Serializer):
+    """
+    Oauth Application owner serializer.
+    """
+    email = serializers.EmailField()
+    username = serializers.CharField(max_length=USERNAME_MAX_LENGTH)
+    fullname = serializers.CharField(max_length=255, write_only=True)
+    permissions = serializers.ListField(
+        child=serializers.CharField(),
+        allow_null=True,
+        write_only=True,
+        required=False,
+    )
+
+
+class OauthApplicationSerializer(serializers.ModelSerializer):
+    """
+    Oauth Application model serializer.
+    """
+    user = OauthApplicationUserSerializer()
+
+    class Meta:
+        """Meta class."""
+        model = Application
+        read_only_fields = ('created', 'updated', )
+        fields = '__all__'

--- a/eox_core/api/support/v1/tests/test_oauth_applications.py
+++ b/eox_core/api/support/v1/tests/test_oauth_applications.py
@@ -1,0 +1,396 @@
+"""
+Test module for the OauthApplicationAPIView class.
+"""
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+from django.urls import reverse
+from mock import Mock, patch
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from eox_core.api.support.v1.views import User
+
+
+class OauthApplicationAPIViewTest(APITestCase):  # pylint: disable=too-many-instance-attributes
+    """Oauth Application API TestCase."""
+
+    def setUp(self):
+        """
+        setup.
+        """
+        super().setUp()
+        self.api_user = User(
+            username='staff',
+            email='staffuser@example.com',
+            is_staff=True,
+        )
+        self.url = reverse('eox-support-api:eox-support-api:edxapp-oauth-application')
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.api_user)
+        self.site = Site.objects.create(
+            domain='testing-site.edunext.io',
+            name='testing-site',
+        )
+        self.user = User.objects.create(
+            username='johndoe',
+            email='johndoe@example.com',
+        )
+        self.content_type = ContentType.objects.get_for_model(User)
+        self.permission_test_1 = Permission.objects.get_or_create(  # pylint: disable=unused-variable
+            codename='test_1',
+            name='Can access test-1 API',
+            content_type=self.content_type,
+        )
+        self.permission_test_2 = Permission.objects.get_or_create(  # pylint: disable=unused-variable
+            codename='test_2',
+            name='Can access test-2 API',
+            content_type=self.content_type,
+        )
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.UserSignupSource')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_with_new_user(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_user_signup_source,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where an Oauth Application is created
+        with a new user.
+
+        Expected behavior:
+            - The Oauth App and the User instances are created.
+            - Status code 200.
+        """
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.side_effect = User.DoesNotExist
+        mock_create_edxapp_user.return_value = self.user, ""
+        mock_get_user_signup_source.return_value = Mock()
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_1", "test_2"]
+            },
+            "redirect_uris": "http://testing-site.io/ http://testing-site.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertTrue(data["name"], response.data["name"])
+        self.assertTrue(self.user.user_permissions.filter(codename="test_1").exists())
+        self.assertTrue(self.user.user_permissions.filter(codename="test_2").exists())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_called_once()
+        mock_get_or_create_site.assert_called_once()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.UserSignupSource')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_with_existing_user_and_permissions(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_user_signup_source,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where an Oauth Application is created
+        with an existing user.
+
+        Expected behavior:
+            - The Oauth App is created with the existing user.
+            - Status code 200.
+        """
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        mock_get_user_signup_source.return_value = Mock()
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_1", "test_2"]
+            },
+            "redirect_uris": "http://testing-site2.io/ http://testing-site2.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application 2",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertTrue(data["name"], response.data["name"])
+        self.assertTrue(self.user.user_permissions.filter(codename="test_1").exists())
+        self.assertTrue(self.user.user_permissions.filter(codename="test_2").exists())
+        self.assertEqual(2, self.user.user_permissions.all().count())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_called_once()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_with_wrong_data(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where the data sended in the
+        request is incomplete or incorrect.
+
+        Expected behavior:
+            - Status code 400 BAD REQUEST.
+        """
+        message = b'{"authorization_grant_type":["This field is required."]}'
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_1", "test_2"]
+            },
+            "client_type": "confidential",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(message, response.content)
+        mock_get_edxapp_user.assert_not_called()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_not_called()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.UserSignupSource')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_with_wrong_permissions_for_user(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_user_signup_source,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where the permissions sent for the user
+        don't exist.
+
+        Expected behavior:
+            - The Oauth App and the User instances are created,
+            but the user has no permissions granted.
+            - Status code 200.
+        """
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        mock_get_user_signup_source.return_value = Mock()
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_7", "test_8"]
+            },
+            "redirect_uris": "http://testing-site2.io/ http://testing-site2.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application 3",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertTrue(data["name"], response.data["name"])
+        self.assertFalse(self.user.user_permissions.filter(codename="test_7").exists())
+        self.assertFalse(self.user.user_permissions.filter(codename="test_8").exists())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_called_once()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.UserSignupSource')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_get_existing_oauth_application(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_user_signup_source,
+        mock_get_or_create_site,
+    ):
+        """Tests the case an Oauth Application with the same
+        information already exists.
+
+        Expected behavior:
+            - Returns the existent Oauth Application.
+            - Status code 200.
+        """
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        mock_get_user_signup_source.return_value = Mock()
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_1", "test_2"]
+            },
+            "redirect_uris": "http://testing-site.io/ http://testing-site.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertTrue(data["name"], response.data["name"])
+        self.assertEqual(1, Application.objects.filter(name=data["name"]).count())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_called_once()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_when_get_or_create_edxapp_user_fails(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where the methods the get or create
+        the edxapp user fails.
+
+        Expected behavior:
+            - The Oauth App is not created.
+            - Status code 500.
+        """
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.side_effect = User.DoesNotExist
+        mock_create_edxapp_user.return_value = None, ""
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["test_1", "test_2"]
+            },
+            "redirect_uris": "http://testing-site.io/ http://testing-site.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application 4",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_500_INTERNAL_SERVER_ERROR, response.status_code)
+        self.assertFalse(Application.objects.filter(name=data["name"]).exists())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_called_once()
+        mock_get_or_create_site.assert_called_once()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_with_wrong_user_data(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where the user information
+        is incomplete or has the wrong format in the
+        request data.
+
+        Expected behavior:
+            - Status code 400 Bad Request.
+        """
+        message = b'{"user":{"username":["This field is required."]}}'
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "permissions": ["test_1", "test_2"]
+            },
+            "redirect_uris": "http://testing-site.io/ http://testing-site.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application 5",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(message, response.content)
+        self.assertFalse(Application.objects.filter(name=data["name"]).exists())
+        mock_get_edxapp_user.assert_not_called()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_not_called()
+
+    @patch('eox_core.api.support.v1.views.get_or_create_site_from_oauth_app_uris')
+    @patch('eox_core.api.support.v1.views.UserSignupSource')
+    @patch('eox_core.api.support.v1.views.create_edxapp_user')
+    @patch('eox_core.api.support.v1.views.get_edxapp_user')
+    def test_create_oauth_application_without_sending_user_permissions(
+        self,
+        mock_get_edxapp_user,
+        mock_create_edxapp_user,
+        mock_get_user_signup_source,
+        mock_get_or_create_site,
+    ):
+        """Tests the case where an Oauth Application is created
+        without sending any permissions to assign to the user.
+
+        Expected behavior:
+            - The Oauth App is created.
+            - Status code 200.
+        """
+        self.user.user_permissions.clear()
+        mock_get_or_create_site.return_value = self.site
+        mock_get_edxapp_user.return_value = self.user
+        mock_get_user_signup_source.return_value = Mock()
+        data = {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": [],
+            },
+            "redirect_uris": "http://testing-site6.io/ http://testing-site6.io",
+            "client_type": "confidential",
+            "authorization_grant_type": "client-credentials",
+            "name": "test-application 6",
+            "skip_authorization": True,
+        }
+
+        response = self.client.post(self.url, data=data, format="json")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertTrue(data["name"], response.data["name"])
+        self.assertEqual(0, self.user.user_permissions.all().count())
+        mock_get_edxapp_user.assert_called_once()
+        mock_create_edxapp_user.assert_not_called()
+        mock_get_or_create_site.assert_called_once()

--- a/eox_core/api/support/v1/urls.py
+++ b/eox_core/api/support/v1/urls.py
@@ -9,4 +9,5 @@ app_name = 'eox_core'  # pylint: disable=invalid-name
 urlpatterns = [  # pylint: disable=invalid-name
     url(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
     url(r'^user/replace-username/$', views.EdxappReplaceUsername.as_view(), name='edxapp-replace-username'),
+    url(r'^oauth-application/$', views.OauthApplicationAPIView.as_view(), name='edxapp-oauth-application'),
 ]

--- a/eox_core/api/support/v1/views.py
+++ b/eox_core/api/support/v1/views.py
@@ -7,20 +7,38 @@ from __future__ import absolute_import, unicode_literals
 import logging
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.sites.shortcuts import get_current_site
 from django.db import transaction
+from oauth2_provider.models import Application
+from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import NotFound
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from eox_core.api.support.v1.permissions import EoxCoreSupportAPIPermission
-from eox_core.api.support.v1.serializers import WrittableEdxappRemoveUserSerializer, WrittableEdxappUsernameSerializer
+from eox_core.api.support.v1.serializers import (
+    OauthApplicationSerializer,
+    WrittableEdxappRemoveUserSerializer,
+    WrittableEdxappUsernameSerializer,
+)
 from eox_core.api.v1.serializers import EdxappUserReadOnlySerializer
 from eox_core.api.v1.views import UserQueryMixin
 from eox_core.edxapp_wrapper.bearer_authentication import BearerAuthentication
 from eox_core.edxapp_wrapper.comments_service_users import replace_username_cs_user
-from eox_core.edxapp_wrapper.users import delete_edxapp_user, get_edxapp_user
+from eox_core.edxapp_wrapper.users import (
+    create_edxapp_user,
+    delete_edxapp_user,
+    get_edxapp_user,
+    get_user_signup_source,
+)
+from eox_core.utils import get_or_create_site_from_oauth_app_uris
+
+User = get_user_model()
+UserSignupSource = get_user_signup_source()  # pylint: disable=invalid-name
 
 try:
     from eox_audit_model.decorators import audit_drf_api
@@ -70,7 +88,7 @@ class EdxappUser(UserQueryMixin, APIView):
         data["site"] = get_current_site(request)
         data["user"] = get_edxapp_user(**query)
 
-        message, status = delete_edxapp_user(**data)
+        message, status = delete_edxapp_user(**data)  # pylint: disable=redefined-outer-name
 
         return Response(message, status=status)
 
@@ -127,3 +145,104 @@ class EdxappReplaceUsername(UserQueryMixin, APIView):
             user, custom_fields=admin_fields, context={"request": request}
         )
         return Response(serialized_user.data)
+
+
+class OauthApplicationAPIView(UserQueryMixin, APIView):
+    """
+    Handles requests related to the
+    django_oauth_toolkit Application object.
+    """
+
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
+    permission_classes = (EoxCoreSupportAPIPermission,)
+    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+
+    @audit_drf_api(action='Generate Oauth Application.', method_name='eox_core_api_method')
+    def post(self, request, *args, **kwargs):  # pylint: disable=too-many-locals
+        """
+        Creates a new Oauth Application from django_oauth_toolkit.
+
+        This endpoint assumes that the URLs sent in the redirect_uris
+        parameter are correct.
+
+        In order to generate a valid application, this endpoint
+        does multiple things:
+        1 - Get or Create an edxapp user which will be the owner
+        of the Application.
+        2 - Grant permissions to the user that were sent in the
+        "permissions" list.
+        3 - Create User SignUp Source with the created user and the site
+            sent in the redirect_uris field.
+        4 - Create Application.
+
+        Note: make sure to send the codenames of the permissions
+        you want to grant to the user in the permissions list.
+        Also, send the urls in the redirect_uris separated by
+        simple whitespaces to avoid any errors during the creation.
+
+        For example:
+
+        **Requests**:
+            POST <domain>/eox-core/support-api/v1/oauth-application/
+
+        **Request body**:
+        {
+            "user": {
+                "fullname": "John Doe",
+                "email": "johndoe@example.com",
+                "username": "johndoe",
+                "permissions": ["can_call_eox_core", "can_call_eox_tenant"]
+            },
+            "redirect_uris": "http://testing-site.io/ http://testing-site.io",
+            "client_type":"confidential",
+            "authorization_grant_type":"client-credentials",
+            "name": "test-application",
+            "skip_authorization": true
+        }
+
+        **Response values**:
+            - 200: Success, the Oauth Application has been created.
+            - 400: Bad request, invalid request body format.
+            - 500: The server has failed to get or create the.
+            owner user for the application.
+        """
+        message = "Could not get or create edxapp User"
+
+        serializer = OauthApplicationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data = serializer.validated_data
+        user_creation_data = data.pop('user', {})
+        user_permissions = user_creation_data.pop('permissions', [])
+        site = get_or_create_site_from_oauth_app_uris(data.get('redirect_uris', ''))
+
+        user_creation_data.update({
+            'skip_extra_registration_fields': True,
+            'activate_user': True,
+            'skip_password': True,
+            'site': site,
+        })
+
+        # Get or create user
+        try:
+            user = get_edxapp_user(**user_creation_data)
+        except (NotFound, User.DoesNotExist):
+            user, message = create_edxapp_user(**user_creation_data)
+
+        if not user:
+            LOG.error(message)
+
+            return Response(message, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # Create SignUp Source in the Oauth Application site
+        UserSignupSource.objects.get_or_create(user=user, site=site.name)
+
+        # Grant permissions to user
+        permissions = Permission.objects.filter(codename__in=user_permissions)
+        user.user_permissions.add(*permissions)
+
+        # Create Oauth Application
+        data['user'] = user
+        application, _ = Application.objects.get_or_create(**data)
+
+        return Response(OauthApplicationSerializer(application).data, status=status.HTTP_200_OK)

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -10,6 +10,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'django.contrib.sites',
     'edx_proctoring',
     'django_filters',
     'oauth2_provider',

--- a/eox_core/tests/test_utils.py
+++ b/eox_core/tests/test_utils.py
@@ -2,9 +2,11 @@
 """
 Test module for Utils
 """
+from django.contrib.sites.models import Site
 from django.test import TestCase
+from mock import patch
 
-from eox_core.utils import fasthash
+from eox_core.utils import fasthash, get_domain_from_oauth_app_uris, get_or_create_site_from_oauth_app_uris
 
 
 class UtilsTest(TestCase):
@@ -12,9 +14,104 @@ class UtilsTest(TestCase):
     Test the functions included on utils module
     """
 
+    def setUp(self):
+        """
+        setup.
+        """
+        super().setUp()
+        self.domain_1 = 'test.academy.edunext.io'
+        self.domain_2 = 'test.bragi.edunext.io'
+        self.site_1 = Site.objects.create(
+            domain=self.domain_1,
+            name=self.domain_1,
+        )
+        self.site_2 = Site.objects.create(
+            domain=self.domain_2,
+            name="Bragi Testing Site",
+        )
+        self.redirect_uris_http = "http://bragi.localhost:18000/  http://bragi.localhost:18000"
+        self.redirect_uris_https = "https://classroomusb.edunext.co https://classroomusb.edunext.co/"
+
     def test_fasthash_call(self):
         """
         Answers the question: Can we apply the fasthash method?
         """
         test_str = "test_str"
         fasthash(test_str)
+
+    def test_get_domain_from_oauth_app_uris_http_protocol(self):
+        """Tests the get_domain_from_oauth_app_uris function
+        when the redirect_uris have URLs with http protocol.
+
+        Expected behavior:
+            - Returns de domain.
+        """
+        domain = get_domain_from_oauth_app_uris(self.redirect_uris_http)
+
+        self.assertEqual('bragi.localhost', domain)
+
+    def test_get_domain_from_oauth_app_uris_https_protocol(self):
+        """Tests the get_domain_from_oauth_app_uris function
+        when the redirect_uris have URLs with https protocol.
+
+        Expected behavior:
+            - Returns de domain.
+        """
+        domain = get_domain_from_oauth_app_uris(self.redirect_uris_https)
+
+        self.assertEqual('classroomusb.edunext.co', domain)
+
+    @patch("eox_core.utils.get_domain_from_oauth_app_uris")
+    def test_get_or_create_site_from_oauth_app_uris_existing_site(self, mock_get_domain):
+        """Tests the get_or_create_site_from_oauth_app_uris function
+        when the redirect_uris are from an existing Django site.
+
+        Expected behavior:
+            - Returns de existing site.
+        """
+        mock_get_domain.return_value = self.domain_1
+
+        site = get_or_create_site_from_oauth_app_uris(self.redirect_uris_https)
+
+        self.assertEqual(self.domain_1, site.domain)
+        self.assertEqual(1, Site.objects.filter(domain=self.domain_1).count())
+        mock_get_domain.assert_called_once()
+
+    @patch("eox_core.utils.get_domain_from_oauth_app_uris")
+    def test_get_or_create_site_from_oauth_app_uris_existing_site_with_different_name(
+        self,
+        mock_get_domain,
+    ):
+        """Tests the get_or_create_site_from_oauth_app_uris function
+        when the redirect_uris are from an existing Django site.
+
+        Expected behavior:
+            - Returns de existing site.
+        """
+        mock_get_domain.return_value = self.domain_2
+
+        site = get_or_create_site_from_oauth_app_uris(self.redirect_uris_https)
+
+        self.assertEqual(self.domain_2, site.domain)
+        self.assertEqual(1, Site.objects.filter(domain=self.domain_2).count())
+        mock_get_domain.assert_called_once()
+
+    @patch("eox_core.utils.get_domain_from_oauth_app_uris")
+    def test_get_or_create_site_from_oauth_app_uris_new_site(
+        self,
+        mock_get_domain,
+    ):
+        """Tests the get_or_create_site_from_oauth_app_uris function
+        when the redirect_uris don't have a Django Site.
+
+        Expected behavior:
+            - Creates and returns the new site.
+        """
+        new_site_domain = "new-site.edunext.io"
+        mock_get_domain.return_value = new_site_domain
+
+        site = get_or_create_site_from_oauth_app_uris(self.redirect_uris_https)
+
+        self.assertEqual(new_site_domain, site.domain)
+        self.assertEqual(1, Site.objects.filter(domain=self.domain_1).count())
+        mock_get_domain.assert_called_once()


### PR DESCRIPTION
## Description

In this PR we add a new endpoint in the support API that creates a new [Oauth Application in edxapp](https://openedx.edunext.co/admin/oauth2_provider/application/)

Request example
```
`POST <domain>/eox-core/support-api/v1/oauth-application/`

body: {
    "user": {
        "fullname": "John Doe",
        "email": "johndoe@example.com",
        "username": "johndoe",
        "permissions": ["can_call_eox_core", "can_call_eox_tenant"]
    },
    "redirect_uris": "http://testing-site.io/ http://testing-site.io",
    "client_type":"confidential",
    "authorization_grant_type":"client-credentials",
    "name": "test-application",
    "skip_authorization": true
}
```
## More details on the implementation
In order to create a valid Application, the method has to perform multiple operations:
1. Create a new edxapp user, who will be the owner of the Application. In case there is already a user with the username or email sent, then the existing user is simply returned and assigned to the new application.
2. Grant all permissions to the user in the "permissions" list sent in the request body. This list must contain the `codename` field from the Django permissions that the application owner should have.
3. Create a new Application instance https://github.com/jazzband/django-oauth-toolkit/blob/master/oauth2_provider/models.py#L233

Any of the [Application model fields](https://github.com/jazzband/django-oauth-toolkit/blob/e0c2fc8aebf889a17fc7478dc2864fdeeb38aab1/oauth2_provider/models.py#L42) can be sent in the request body for the creation of the application (with the exception of the `create` and `update` DateTime fields, who are marked in the serializer as read-only), but it works when only sending the basic information such as 

```
-     "redirect_uris"
-     "client_type"
-     "authorization_grant_type"
-     "name"
-     "skip_authorization"
```

The `client_id` and `client_secret` credentials will be automatically generated

## Why is this feature necessary?

The Xman service makes requests to multiple APIs from eox-core and eox-tenant and these endpoints normally use a Bearer Token authentication schema. We need to be able to programmatically generate an Oauth Application in edxapp from the Xman service, so the users in Control Center can successfully authenticate to the APIs via Xman and perform operations on their remote Site in edxapp.

# Testing instructions

You can test this by making the following requests to the eox-core API
```

POST <domain>/eox-core/support-api/v1/oauth-application/

Request body:
{
    "user": {
        "fullname": "John Doe",
        "email": "johndoe@example.com",
        "username": "johndoe",
        "permissions": ["can_call_eox_core", "can_call_eox_tenant"]
    },
    "redirect_uris": "http://testing-site.io/ http://testing-site.io",
    "client_type":"confidential",
    "authorization_grant_type":"client-credentials",
    "name": "test-application",
    "skip_authorization": true
}

```
After making the request and obtaining a successful response, make sure you check that:

- The user has been created
- The permissions have been granted to the user
- A [User signup source](https://openedx.edunext.co/admin/student/usersignupsource/) has been created with the new user and site
- The [edxapp application](https://openedx.edunext.co/admin/oauth2_provider/application/) has been created and it's valid

## Checklist for Merge

- [x] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->