### PR TITLE
feat: add pipelines to add custom registrations fields and custom options in account settings

### DIFF
--- a/eox_core/pipeline.py
+++ b/eox_core/pipeline.py
@@ -7,9 +7,9 @@ from crum import get_current_request
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
-
 from openedx_filters import PipelineStep
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers # pylint: disable=import-error
+
+from eox_core.edxapp_wrapper.configuration_helpers import get_configuration_helper
 from eox_core.edxapp_wrapper.users import (
     generate_password,
     get_user_attribute,
@@ -224,6 +224,7 @@ def ensure_user_has_signup_source(user=None, *args, **kwargs):
             **locals()
         )
 
+
 class AddCustomOptionsOnAccountSettings(PipelineStep):
     """ Pipeline used to add custom option fields in account settings.
 
@@ -244,13 +245,15 @@ class AddCustomOptionsOnAccountSettings(PipelineStep):
         """ Run the pipeline filter. """
         extended_profile_fields = context.get("extended_profile_fields", [])
 
-        custom_options, field_labels_map = self._get_custom_context(extended_profile_fields)  # pylint: disable=line-too-long
+        custom_options, field_labels_map = self._get_custom_context(extended_profile_fields)
 
-        extended_profile_field_options = configuration_helpers.get_value('EXTRA_FIELD_OPTIONS', custom_options)  # pylint: disable=line-too-long
+        conf_helper = get_configuration_helper()
+
+        extended_profile_field_options = conf_helper.get_value('EXTRA_FIELD_OPTIONS', custom_options)
         extended_profile_field_option_tuples = {}
         for field in extended_profile_field_options.keys():
             field_options = extended_profile_field_options[field]
-            extended_profile_field_option_tuples[field] = [(option.lower(), option) for option in field_options]  # pylint: disable=line-too-long
+            extended_profile_field_option_tuples[field] = [(option.lower(), option) for option in field_options]
 
         for field in custom_options:
             field_dict = {
@@ -265,7 +268,7 @@ class AddCustomOptionsOnAccountSettings(PipelineStep):
             else:
                 field_dict["field_type"] = "TextField"
 
-            field_index = next((index for (index, d) in enumerate(extended_profile_fields) if d["field_name"] == field_dict["field_name"]), None)  # pylint: disable=line-too-long
+            field_index = next((index for (index, d) in enumerate(extended_profile_fields) if d["field_name"] == field_dict["field_name"]), None)
             if field_index is not None:
                 context["extended_profile_fields"][field_index] = field_dict
         return context
@@ -284,8 +287,8 @@ class AddCustomOptionsOnAccountSettings(PipelineStep):
                 raise ImproperlyConfigured(msg)
 
             field_label = field.get("label")
-            if not any(extended_field['field_name'] == field_name for extended_field in extended_profile_fields) and field_label:  # pylint: disable=line-too-long
-                field_labels[field_name] = _(field_label)  # pylint: disable=translation-of-non-string
+            if not any(extended_field['field_name'] == field_name for extended_field in extended_profile_fields) and field_label:
+                field_labels[field_name] = (field_label)
 
             options = field.get("options")
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,3 +14,4 @@ edx-opaque-keys[django]==2.3.0
 openedx-events==0.13.0
 django
 click
+openedx-filters==1.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -69,6 +69,7 @@ django==3.2.16
     #   event-tracking
     #   jsonfield
     #   openedx-events
+    #   openedx-filters
 django-crum==0.7.9
     # via
     #   edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -183,6 +183,8 @@ oauthlib==3.2.2
     # via django-oauth-toolkit
 openedx-events==0.13.0
     # via -r requirements/base.in
+openedx-filters==1.2.0
+    # via -r requirements/base.in
 packaging==23.0
     # via drf-yasg
 pbr==5.11.1

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,6 @@ click==8.1.3
     # via
     #   -c requirements/constraints.txt
     #   pip-tools
-packaging==23.0
     # via build
 pip-tools==6.12.1
     # via -r requirements/pip-tools.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -279,6 +279,8 @@ oauthlib==3.2.2
     #   django-oauth-toolkit
 openedx-events==0.13.0
     # via -r requirements/base.txt
+openedx-filters==1.2.0
+    # via -r requirements/base.txt
 packaging==23.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description

This PR is to add a pipeline for `AccountSettingsRenderStarted` filter, we added `AddCustomOptionsOnAccountSettings` pipeline. It implements custom options on account settings context added by `EDNX_CUSTOM_REGISTRATION_FIELDS` setting.

This pipeline is following https://edunext.atlassian.net/browse/DS-303 ticket and JU-11 Saas migration step.

## Testing instructions

Add in your tenant settings:

```json
   "EDNX_CUSTOM_REGISTRATION_FIELDS": [
       {
           "label": "Document Type",
           "name": "type_document",
           "options": [
               "DNI",
               "PASSPORT",
               "ID"
           ],
           "type": "select"
       },
       {
           "label": "Document Number",
           "name": "personal_id",
           "type": "text"
       },
       {
           "label": "Phone number",
           "name": "mobile",
           "type": "text"
       },
       {
           "label": "Address",
           "name": "address",
           "type": "text"
       },
       {
           "label": "Company Name",
           "name": "company",
           "type": "text"
       }
   ],
   "REGISTRATION_EXTRA_FIELDS": {
       "address": "required",
       "company": "optional",
       "country": "hidden",
       "gender": "required",
       "goals": "hidden",
       "honor_code": "hidden",
       "level_of_education": "hidden",
       "mailing_address": "hidden",
       "mobile": "required",
       "personal_id": "required",
       "terms_of_service": "required",
       "type_document": "required",
       "year_of_birth": "hidden"
   },
   "REGISTRATION_FIELD_ORDER": [
       "gender",
       "type_document",
       "personal_id",
       "email",
       "mobile",
       "address",
       "company"
   ],
   "extended_profile_fields": [
       "type_document",
       "personal_id",
       "mobile",
       "address",
       "company"
   ],
   "OPEN_EDX_FILTERS_CONFIG": {
        "org.openedx.learning.student.registration.render.started.v1": {
            "fail_silently": false,
            "pipeline": [
                "openedx.core.djangoapps.user_authn.views.registration_form.AddCustomFieldsBeforeRegistration"
            ]
        },
        "org.openedx.learning.student.settings.render.started.v1": {
                  "fail_silently": false,
                  "pipeline": [
                      "openedx.core.djangoapps.user_api.accounts.settings_views.AddCustomOptionsOnAccountSettings"
                  ]
              }
          }

```

Now you look at registration form in http://{lms.base}:8000/register

![image](https://user-images.githubusercontent.com/39854568/200412721-69df7f85-cb88-4953-96ca-21a98e90437b.png)

in http://{lms.base}:8000/admin/auth/user/

![image](https://user-images.githubusercontent.com/39854568/200414826-be5eee43-576c-475f-97d0-d8e73458568e.png)

In http://{lms.base}:8000/account/settings you should look your custom field types, for this example Type Document as List instead of plain text.

![image](https://user-images.githubusercontent.com/39854568/201421497-996d48f1-c4f9-48bd-a64f-ca48a596f92f.png)


You can look full working example of this functionality, screenshots and testing instructions at https://github.com/eduNEXT/edunext-platform/pull/691 PR. 


## Additional information

Currently we have two PRs in upstream to implements its filter and hook.

- https://github.com/openedx/edx-platform/pull/31295
- https://github.com/openedx/openedx-filters/pull/46

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Upstream openedx-filters and edx-platform PRs was merged
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits