### PR TITLE
chore: Upgrade openedx-events to v0.13.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,6 +11,6 @@ django-waffle
 edx-api-doc-tools
 edx-proctoring>=2.0.1
 edx-opaque-keys[django]==2.3.0
-openedx-events==0.8.1
+openedx-events==0.13.0
 django
 click

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -179,7 +179,7 @@ newrelic==7.10.0.175
     #   edx-django-utils
 oauthlib==3.2.1
     # via django-oauth-toolkit
-openedx-events==0.8.1
+openedx-events==0.13.0
     # via -r requirements/base.in
 packaging==21.3
     # via drf-yasg

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -274,7 +274,7 @@ oauthlib==3.2.1
     # via
     #   -r requirements/base.txt
     #   django-oauth-toolkit
-openedx-events==0.8.1
+openedx-events==0.13.0
     # via -r requirements/base.txt
 packaging==21.3
     # via


### PR DESCRIPTION
## Description

In this PR we upgrade the openedx-events library to the v0.13.0, so it can be compatible with the Lilac release of the edunext-platform.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->