### PR TITLE
fix: UnboundLocalError for enrollment backend

### DIFF
--- a/eox_core/edxapp_wrapper/backends/enrollment_l_v1.py
+++ b/eox_core/edxapp_wrapper/backends/enrollment_l_v1.py
@@ -208,6 +208,7 @@ def _enroll_on_course(user, course_id, *args, **kwargs):
             LOG.info('Force create enrollment %s, %s, %s', username, course_id, mode)
             enrollment = _force_create_enrollment(username, course_id, mode, is_active)
         else:
+            err_msg = None
             if not str(err):
                 err_msg = err.__class__.__name__
             raise APIException(detail=err_msg if err_msg else err) from err


### PR DESCRIPTION
This PR is to solve https://github.com/eduNEXT/eox-core/issues/240

## How to test

You can try to enroll user to a course twice, with this fix, in the second enroll it show the the error message correctly:

![image](https://user-images.githubusercontent.com/39854568/212115573-d37a044e-6334-4841-9dda-1e44d9c991b1.png)

Otherwise:

![image](https://user-images.githubusercontent.com/39854568/212115249-e8383aeb-802a-4a6b-bf7f-19d5221c1aac.png)
