### PR TITLE
feat: allow sentry to receive extra params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,9 +181,11 @@ The plugin offers some integrations listed below:
 
         EOX_CORE_SENTRY_INTEGRATION_DSN: <your DSN value>
         EOX_CORE_SENTRY_IGNORED_ERRORS: [] # optional
+        EOX_CORE_SENTRY_EXTRA_OPTIONS: {} # optional
 
      By default, **EOX_CORE_SENTRY_INTEGRATION_DSN** setting is None, which disables the sentry integration.
      **EOX_CORE_SENTRY_IGNORED_ERRORS** is optional. It is a list of the exceptions you want to ignore. For instance, it can be defined as:
+     **EOX_CORE_SENTRY_EXTRA_OPTIONS** is optional. It is a dictionary with extra options to be passed to the sentry client. For instance, it can be defined as:
 
      .. code-block:: yaml
 
@@ -191,6 +193,12 @@ The plugin offers some integrations listed below:
           'xmodule.exceptions.NotFoundError',
           'openedx.core.djangoapps.user_authn.exceptions.AuthFailedError',
         ]
+        EOX_CORE_SENTRY_EXTRA_OPTIONS:
+            experiments: 
+               profiles_sample_rate: 0.5
+            another_client_parameter: 'value'
+
+        
 
 EOX core migration notes
 ========================

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -76,6 +76,7 @@ def plugin_settings(settings):
     # regex, the exception is ignored if any of the regex matches the traceback text.
     settings.EOX_CORE_SENTRY_IGNORED_ERRORS = []
     settings.EOX_CORE_SENTRY_ENVIRONMENT = None
+    settings.EOX_CORE_SENTRY_EXTRA_OPTIONS = {}
 
     if find_spec('eox_audit_model') and EOX_AUDIT_MODEL_APP not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS.append(EOX_AUDIT_MODEL_APP)

--- a/eox_core/settings/production.py
+++ b/eox_core/settings/production.py
@@ -138,15 +138,24 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
 
     if sentry_sdk is not None and sentry_integration_dsn is not None:
         from eox_core.integrations.sentry import ExceptionFilterSentry  # pylint: disable=import-outside-toplevel
-        sentry_sdk.init(
-            before_send=ExceptionFilterSentry(),
-            dsn=sentry_integration_dsn,
-            environment=sentry_environment,
-            integrations=[
-                DjangoIntegration(),
-            ],
-            # If you wish to associate users to errors (assuming you are using
-            # django.contrib.auth) you may enable sending PII data.
-            send_default_pii=True,
-            **sentry_extra_options
-        )
+        try:
+            sentry_sdk.init(
+                before_send=ExceptionFilterSentry(),
+                dsn=sentry_integration_dsn,
+                environment=sentry_environment,
+                integrations=[
+                    DjangoIntegration(),
+                ],
+                send_default_pii=True,
+                **sentry_extra_options
+            )
+        except TypeError:
+            sentry_sdk.init(
+                before_send=ExceptionFilterSentry(),
+                dsn=sentry_integration_dsn,
+                environment=sentry_environment,
+                integrations=[
+                    DjangoIntegration(),
+                ],
+                send_default_pii=True
+            )

--- a/eox_core/settings/production.py
+++ b/eox_core/settings/production.py
@@ -131,6 +131,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_CORE_SENTRY_ENVIRONMENT',
         settings.EOX_CORE_SENTRY_ENVIRONMENT
     )
+    sentry_extra_options = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_CORE_SENTRY_EXTRA_OPTIONS',
+        settings.EOX_CORE_SENTRY_EXTRA_OPTIONS
+    )
 
     if sentry_sdk is not None and sentry_integration_dsn is not None:
         from eox_core.integrations.sentry import ExceptionFilterSentry  # pylint: disable=import-outside-toplevel
@@ -141,7 +145,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
             integrations=[
                 DjangoIntegration(),
             ],
-
+            **sentry_extra_options,
             # If you wish to associate users to errors (assuming you are using
             # django.contrib.auth) you may enable sending PII data.
             send_default_pii=True

--- a/eox_core/settings/production.py
+++ b/eox_core/settings/production.py
@@ -145,8 +145,8 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
             integrations=[
                 DjangoIntegration(),
             ],
-            **sentry_extra_options,
             # If you wish to associate users to errors (assuming you are using
             # django.contrib.auth) you may enable sending PII data.
-            send_default_pii=True
+            send_default_pii=True,
+            **sentry_extra_options
         )


### PR DESCRIPTION
## Description

This PR fixes the issue #247 

## Testing instructions

Set the variable `EOX_CORE_SENTRY_EXTRA_OPTIONS` to any custom param that sentry accepts