### PR TITLE
fix: update urls in favor of re_path for deprecation

### DIFF
--- a/eox_core/api/data/v1/urls.py
+++ b/eox_core/api/data/v1/urls.py
@@ -1,7 +1,7 @@
 """
 URLs for the Microsite API
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from .routers import ROUTER
 from .views import CeleryTasksStatus
@@ -9,6 +9,6 @@ from .views import CeleryTasksStatus
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^v1/', include((ROUTER.urls, 'eox_core'), namespace='eox-data-api-v1')),
-    url(r'^v1/tasks/(?P<task_id>.*)$', CeleryTasksStatus.as_view(), name="celery-data-api-tasks"),
+    re_path(r'^v1/', include((ROUTER.urls, 'eox_core'), namespace='eox-data-api-v1')),
+    re_path(r'^v1/tasks/(?P<task_id>.*)$', CeleryTasksStatus.as_view(), name="celery-data-api-tasks"),
 ]

--- a/eox_core/api/support/urls.py
+++ b/eox_core/api/support/urls.py
@@ -1,9 +1,9 @@
 """ Support API urls.py """
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^v1/', include('eox_core.api.support.v1.urls', namespace='eox-support-api')),
+    re_path(r'^v1/', include('eox_core.api.support.v1.urls', namespace='eox-support-api')),
 ]

--- a/eox_core/api/support/v1/urls.py
+++ b/eox_core/api/support/v1/urls.py
@@ -1,13 +1,13 @@
 """ urls.py """
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from eox_core.api.support.v1 import views
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
-    url(r'^user/replace-username/$', views.EdxappReplaceUsername.as_view(), name='edxapp-replace-username'),
-    url(r'^oauth-application/$', views.OauthApplicationAPIView.as_view(), name='edxapp-oauth-application'),
+    re_path(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
+    re_path(r'^user/replace-username/$', views.EdxappReplaceUsername.as_view(), name='edxapp-replace-username'),
+    re_path(r'^oauth-application/$', views.OauthApplicationAPIView.as_view(), name='edxapp-oauth-application'),
 ]

--- a/eox_core/api/task_dispatcher/v1/urls.py
+++ b/eox_core/api/task_dispatcher/v1/urls.py
@@ -1,12 +1,12 @@
 """
 Task dispatcher api urls
 """
-from django.conf.urls import url
+from django.urls import re_path
 
 from eox_core.api.task_dispatcher.v1.views import TaskAPI
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [
-    url(r'^v1/tasks/$', TaskAPI.as_view(), name='task-api'),
+    re_path(r'^v1/tasks/$', TaskAPI.as_view(), name='task-api'),
 ]

--- a/eox_core/api/urls.py
+++ b/eox_core/api/urls.py
@@ -1,9 +1,9 @@
 """ urls.py """
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^v1/', include('eox_core.api.v1.urls', namespace='eox-api')),
+    re_path(r'^v1/', include('eox_core.api.v1.urls', namespace='eox-api')),
 ]

--- a/eox_core/api/v1/urls.py
+++ b/eox_core/api/v1/urls.py
@@ -1,21 +1,21 @@
 """ urls.py """
 
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 
 from eox_core.api.v1 import views
 
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
-    url(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
-    url(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
-    url(r'^pre-enrollment/$', views.EdxappPreEnrollment.as_view(), name='edxapp-pre-enrollment'),
-    url(r'^userinfo/$', views.UserInfo.as_view(), name='edxapp-userinfo'),
+    re_path(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
+    re_path(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
+    re_path(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
+    re_path(r'^pre-enrollment/$', views.EdxappPreEnrollment.as_view(), name='edxapp-pre-enrollment'),
+    re_path(r'^userinfo/$', views.UserInfo.as_view(), name='edxapp-userinfo'),
 ]
 
 if getattr(settings, "EOX_CORE_ENABLE_UPDATE_USERS", None):
     urlpatterns += [
-        url(r'^update-user/$', views.EdxappUserUpdater.as_view(), name='edxapp-user-updater'),
+        re_path(r'^update-user/$', views.EdxappUserUpdater.as_view(), name='edxapp-user-updater'),
     ]

--- a/eox_core/api_schema.py
+++ b/eox_core/api_schema.py
@@ -2,7 +2,7 @@
 Swagger view generator
 """
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from drf_yasg.generators import OpenAPISchemaGenerator
 from drf_yasg.openapi import SwaggerDict
 from drf_yasg.views import get_schema_view
@@ -39,14 +39,14 @@ class APISchemaGenerator(OpenAPISchemaGenerator):
 
 
 api_urls = [  # pylint: disable=invalid-name
-    url(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
-    url(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
-    url(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
+    re_path(r'^enrollment/$', views.EdxappEnrollment.as_view(), name='edxapp-enrollment'),
+    re_path(r'^grade/$', views.EdxappGrade.as_view(), name='edxapp-grade'),
+    re_path(r'^user/$', views.EdxappUser.as_view(), name='edxapp-user'),
 ]
 
 if getattr(settings, "EOX_CORE_ENABLE_UPDATE_USERS", None):
     api_urls += [
-        url(r'^update-user/$', views.EdxappUserUpdater.as_view(), name='edxapp-user-updater'),
+        re_path(r'^update-user/$', views.EdxappUserUpdater.as_view(), name='edxapp-user-updater'),
     ]
 
 api_info = make_api_info(  # pylint: disable=invalid-name

--- a/eox_core/urls.py
+++ b/eox_core/urls.py
@@ -1,6 +1,6 @@
 """ urls.py """
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from eox_core import views
 from eox_core.api_schema import docs_ui_view
@@ -8,10 +8,10 @@ from eox_core.api_schema import docs_ui_view
 app_name = 'eox_core'  # pylint: disable=invalid-name
 
 urlpatterns = [  # pylint: disable=invalid-name
-    url(r'^eox-info$', views.info_view),
-    url(r'^api/', include('eox_core.api.urls', namespace='eox-api')),
-    url(r'^data-api/', include('eox_core.api.data.v1.urls', namespace='eox-data-api')),
-    url(r'^api-docs/$', docs_ui_view, name='apidocs-ui'),
-    url(r'^tasks-api/', include('eox_core.api.task_dispatcher.v1.urls', namespace='eox-task-api')),
-    url(r'^support-api/', include('eox_core.api.support.urls', namespace='eox-support-api')),
+    re_path(r'^eox-info$', views.info_view),
+    re_path(r'^api/', include('eox_core.api.urls', namespace='eox-api')),
+    re_path(r'^data-api/', include('eox_core.api.data.v1.urls', namespace='eox-data-api')),
+    re_path(r'^api-docs/$', docs_ui_view, name='apidocs-ui'),
+    re_path(r'^tasks-api/', include('eox_core.api.task_dispatcher.v1.urls', namespace='eox-task-api')),
+    re_path(r'^support-api/', include('eox_core.api.support.urls', namespace='eox-support-api')),
 ]


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

`django.conf.urls.url()` was deprecated in Django 3.0, and is removed in Django 4.0+. To stay updated and be able to use the code with Quince that uses Django 4.0+, we change the `url` function to `re_path`.

The version of Django in Quince: https://github.com/openedx/edx-platform/blob/open-release/quince.master/requirements/edx/base.txt#L184 
Deprecation note: https://code.djangoproject.com/ticket/31534
Example of re_path use in other of our repositories (eox-tenant): https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/api/urls.py

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Rebased master/main
- [x] Squashed commits

## Links


<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->