### PR TITLE
fix: add basename to router register to avoid conflicts with services

### DIFF
--- a/eox_core/api/data/v1/routers.py
+++ b/eox_core/api/data/v1/routers.py
@@ -17,4 +17,8 @@ ROUTER.register(r'course-enrollments', CourseEnrollmentViewset)
 ROUTER.register(r'certificates', CertificateViewSet, basename='generated_certificate')
 ROUTER.register(r'proctored-exams-attempts', ProctoredExamStudentViewSet)
 # Async operations
-ROUTER.register(r'async/course-enrollments-grades', CourseEnrollmentWithGradesViewset)
+ROUTER.register(
+    r'async/course-enrollments-grades',
+    CourseEnrollmentWithGradesViewset,
+    basename="async_course_enrollments_grades",
+)


### PR DESCRIPTION
## Description

This PR solves this issue raised in one of our installations after building and deploying an image with this package installed:

![Screenshot from 2024-05-07 12-31-44](https://github.com/eduNEXT/eox-core/assets/64440265/201fe4fd-8dfa-46b1-b857-cd4e80b96d78)

It looks like [this API endpoint](https://github.com/eduNEXT/eox-core/blob/b1bc5954e2a0936476f1fcd54dfb2d0edcc17e1b/eox_core/api/data/v1/routers.py#L20-L21) conflicts with the enrollments API from the edx-platform. I'm not sure why, though because our installation has been working fine for some time.