### PR TITLE
fix: add improperly configured exception in load permissions function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Please do not update the unreleased notes.
 
 ### Fixed
 
-- **Fix build error**: A new `ImproperlyConfigured` exception is handled when
-  loading the API permissions to avoid errors during the build.
+- **Redwood Compatibility**: Corrected a build-time error, ensuring full
+  compatibility with the Redwood release. For this, a new `ImproperlyConfigured`
+  exception is handled when loading the API permissions.
 
 ### Changed
 
@@ -34,7 +35,7 @@ Please do not update the unreleased notes.
 
 ### Changed
 
-- **Redwood Support**: Upgrade requirements base on edx-platform redwood
+- **Redwood Support**: Upgrade requirements base on edx-platform Redwood
   release, update GitHub workflows with new actions version, and update
   integration test to use new Redwood release with Tutor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
 
+## [v10.5.1](https://github.com/eduNEXT/eox-core/compare/v10.5.0...v10.5.1) - (2024-07-19)
+
+### Fixed
+
+- **Fix build error**: A new `ImproperlyConfigured` exception is handled when
+  loading the API permissions to avoid errors during the build.
+
+### Changed
+
+- **Improve Documentation**: Update the README to include a more detailed
+  description of the project and its features. A new how-to section was
+  included with information about API, Middlewares, and pipelines.
+
 ## [v10.5.0](https://github.com/eduNEXT/eox-core/compare/v10.4.0...v10.5.0) - (2024-07-08)
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Compatibility Notes
 +------------------+--------------+
 | Quince           | >= 10.0      |
 +------------------+--------------+
-| Redwood          | >= 10.5.0    |
+| Redwood          | >= 10.5.1    |
 +------------------+--------------+
 
 ⚠️ The Maple version does not support Django 2.2 but it does support Django 3.2 as of eox-core 7.0.

--- a/eox_core/__init__.py
+++ b/eox_core/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for main eox-core app
 """
-__version__ = '10.5.0'
+__version__ = '10.5.1'

--- a/eox_core/api/v1/permissions.py
+++ b/eox_core/api/v1/permissions.py
@@ -19,7 +19,7 @@ def load_permissions():
     if settings.EOX_CORE_LOAD_PERMISSIONS:
         try:
             content_type = ContentType.objects.get_for_model(User)
-            obj, created = Permission.objects.get_or_create(  # pylint: disable=unused-variable
+            Permission.objects.get_or_create(
                 codename='can_call_eox_core',
                 name='Can access eox-core API',
                 content_type=content_type,

--- a/eox_core/api/v1/permissions.py
+++ b/eox_core/api/v1/permissions.py
@@ -25,10 +25,10 @@ def load_permissions():
                 content_type=content_type,
             )
         except (ProgrammingError, ImproperlyConfigured):
-            # This code runs when the app is loaded, if a migration has not been done a
-            # ProgrammingError or ImproperlyConfugured exception is raised. We are
-            # bypassing those cases to let migrations run smoothly. This error occurs
-            # when building the Open edX image.
+            # This code runs when the app is loaded. If a migration has not been done, a
+            # ProgrammingError is raised. The ImproperlyConfigured exception typically
+            # indicates a configuration issue. We are bypassing these exceptions to allow
+            # the migrations to run smoothly when building the Open edX image.
             pass
 
 

--- a/eox_core/api/v1/permissions.py
+++ b/eox_core/api/v1/permissions.py
@@ -25,8 +25,10 @@ def load_permissions():
                 content_type=content_type,
             )
         except (ProgrammingError, ImproperlyConfigured):
-            # This code runs when the app is loaded, if a migration has not been done a ProgrammingError exception is raised
-            # we are bypassing those cases to let migrations run smoothly.
+            # This code runs when the app is loaded, if a migration has not been done a
+            # ProgrammingError or ImproperlyConfugured exception is raised. We are
+            # bypassing those cases to let migrations run smoothly. This error occurs
+            # when building the Open edX image.
             pass
 
 

--- a/eox_core/api/v1/permissions.py
+++ b/eox_core/api/v1/permissions.py
@@ -6,6 +6,7 @@ Custom API permissions module
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import ProgrammingError
 from rest_framework import exceptions, permissions
 
@@ -23,7 +24,7 @@ def load_permissions():
                 name='Can access eox-core API',
                 content_type=content_type,
             )
-        except ProgrammingError:
+        except (ProgrammingError, ImproperlyConfigured):
             # This code runs when the app is loaded, if a migration has not been done a ProgrammingError exception is raised
             # we are bypassing those cases to let migrations run smoothly.
             pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.5.0
+current_version = 10.5.1
 commit = False
 tag = False
 


### PR DESCRIPTION
## Description

This PR adds an `ImproperlyConfigured` exception in `load_permissions` function to avoid errors during the build.

## Error

<details>
<summary>Details of error</summary>

```bash
 => ERROR [production 19/37] RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='openedx/openedx-translations' --revision='o  5.3s
------
 > [production 19/37] RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='openedx/openedx-translations' --revision='open-release/redwood.1':
4.572 Traceback (most recent call last):
4.572   File "/openedx/edx-platform/./manage.py", line 106, in <module>
4.572     execute_from_command_line([sys.argv[0]] + django_args)
4.572   File "/openedx/venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
4.572     utility.execute()
4.572   File "/openedx/venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
4.573     self.fetch_command(subcommand).run_from_argv(self.argv)
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
4.573     self.execute(*args, **cmd_options)
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/management/base.py", line 453, in execute
4.573     self.check()
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/management/base.py", line 485, in check
4.573     all_issues = checks.run_checks(
4.573                  ^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/checks/registry.py", line 88, in run_checks
4.573     new_errors = check(app_configs=app_configs, databases=databases)
4.573                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/checks/urls.py", line 42, in check_url_namespaces_unique
4.573     all_namespaces = _load_all_namespaces(resolver)
4.573                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/core/checks/urls.py", line 61, in _load_all_namespaces
4.573     url_patterns = getattr(resolver, "url_patterns", [])
4.573                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/utils/functional.py", line 57, in __get__
4.573     res = instance.__dict__[self.name] = self.func(instance)
4.573                                          ^^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/urls/resolvers.py", line 715, in url_patterns
4.573     patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
4.573                        ^^^^^^^^^^^^^^^^^^^
4.573   File "/openedx/venv/lib/python3.11/site-packages/django/utils/functional.py", line 57, in __get__
4.574     res = instance.__dict__[self.name] = self.func(instance)
4.574                                          ^^^^^^^^^^^^^^^^^^^
4.574   File "/openedx/venv/lib/python3.11/site-packages/django/urls/resolvers.py", line 708, in urlconf_module
4.574     return import_module(self.urlconf_name)
4.574            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.574   File "/opt/pyenv/versions/3.11.8/lib/python3.11/importlib/__init__.py", line 126, in import_module
4.574     return _bootstrap._gcd_import(name[level:], package, level)
4.574            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.574   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
4.574   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
4.574   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
4.574   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
4.574   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
4.574   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
4.574   File "/openedx/edx-platform/lms/urls.py", line 998, in <module>
4.575     urlpatterns.extend(get_plugin_url_patterns(ProjectType.LMS))
4.575                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.575   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/plugin_urls.py", line 34, in get_plugin_url_patterns
4.575     return [
4.575            ^
4.575   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/plugin_urls.py", line 35, in <listcomp>
4.575     _get_url(url_module_path, url_config)
4.575   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/plugin_urls.py", line 24, in _get_url
4.575     return re_path(regex, include((url_module_path, app_name), namespace=namespace))
4.575                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.575   File "/openedx/venv/lib/python3.11/site-packages/django/urls/conf.py", line 38, in include
4.575     urlconf_module = import_module(urlconf_module)
4.575                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.575   File "/opt/pyenv/versions/3.11.8/lib/python3.11/importlib/__init__.py", line 126, in import_module
4.575     return _bootstrap._gcd_import(name[level:], package, level)
4.575            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.575   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
4.575   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
4.575   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
4.575   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
4.575   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
4.575   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
4.575   File "/openedx/venv/lib/python3.11/site-packages/eox_core/urls.py", line 6, in <module>
4.576     from eox_core.api_schema import docs_ui_view
4.576   File "/openedx/venv/lib/python3.11/site-packages/eox_core/api_schema.py", line 12, in <module>
4.576     from eox_core.api.v1 import views
4.576   File "/openedx/venv/lib/python3.11/site-packages/eox_core/api/v1/__init__.py", line 8, in <module>
4.576     load_permissions()
4.576   File "/openedx/venv/lib/python3.11/site-packages/eox_core/api/v1/permissions.py", line 20, in load_permissions
4.576     content_type = ContentType.objects.get_for_model(User)
4.576                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.576   File "/openedx/venv/lib/python3.11/site-packages/django/contrib/contenttypes/models.py", line 52, in get_for_model
4.576     ct = self.get(app_label=opts.app_label, model=opts.model_name)
4.576          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.576   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
4.576     return getattr(self.get_queryset(), name)(*args, **kwargs)
4.576            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.576   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/query.py", line 633, in get
4.576     num = len(clone)
4.576           ^^^^^^^^^^
4.576   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/query.py", line 380, in __len__
4.577     self._fetch_all()
4.577   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/query.py", line 1881, in _fetch_all
4.577     self._result_cache = list(self._iterable_class(self))
4.577                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.577   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/query.py", line 91, in __iter__
4.577     results = compiler.execute_sql(
4.577               ^^^^^^^^^^^^^^^^^^^^^
4.577   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1549, in execute_sql
4.577     sql, params = self.as_sql()
4.578                   ^^^^^^^^^^^^^
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 736, in as_sql
4.578     extra_select, order_by, group_by = self.pre_sql_setup(
4.578                                        ^^^^^^^^^^^^^^^^^^^
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 84, in pre_sql_setup
4.578     self.setup_query(with_col_aliases=with_col_aliases)
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 73, in setup_query
4.578     self.select, self.klass_info, self.annotation_col_map = self.get_select(
4.578                                                             ^^^^^^^^^^^^^^^^
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 296, in get_select
4.578     sql, params = self.compile(col)
4.578                   ^^^^^^^^^^^^^^^^^
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
4.578     sql, params = node.as_sql(self, self.connection)
4.578                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.578   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/expressions.py", line 1141, in as_sql
4.579     sql = ".".join(map(compiler.quote_name_unless_alias, identifiers))
4.579           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.579   File "/openedx/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 537, in quote_name_unless_alias
4.579     r = self.connection.ops.quote_name(name)
4.579         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4.579   File "/openedx/venv/lib/python3.11/site-packages/django/db/backends/dummy/base.py", line 20, in complain
4.579     raise ImproperlyConfigured(
4.579 django.core.exceptions.ImproperlyConfigured: settings.DATABASES is improperly configured. Please supply the ENGINE value. Check settings documentation for more details.
------
Dockerfile:183
--------------------
 181 |     # Pull latest translations via atlas
 182 |     RUN make clean_translations
 183 | >>> RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='openedx/openedx-translations' --revision='open-release/redwood.1'
 184 |     RUN ./manage.py lms --settings=tutor.i18n pull_xblock_translations --repository='openedx/openedx-translations' --revision='open-release/redwood.1'
 185 |     RUN atlas pull --repository='openedx/openedx-translations' --revision='open-release/redwood.1'  \
--------------------
ERROR: failed to solve: process "/bin/sh -c ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='openedx/openedx-translations' --revision='open-release/redwood.1'" did not complete successfully: exit code: 1
Error: Command failed with status 1: docker buildx build --tag=docker.io/overhangio/openedx:18.1.1-indigo --no-cache --output=type=docker --cache-from=type=registry,ref=docker.io/overhangio/openedx:18.1.1-indigo-cache /home/bryanttv/edunext/tutor/redwood/ednx/env/build/openedx
```

</details>

## Testing instructions

1. Create an environment with Redwood release, you can use [Tutor](https://docs.tutor.overhang.io/index.html) or [TVM](https://github.com/eduNEXT/tvm).
2. Add in your `config.yml` this plugin as extra requirement.

    ```yml
    OPENEDX_EXTRA_PIP_REQUIREMENTS:
    - git+https://github.com/eduNEXT/eox-core.git@bav/fix-load-permissions
    ```
3. Run `tutor images build openedx --no-cache`
4. Your build should finish smoothly.
