### PR TITLE
refactor(ci): update workflow for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,4 +18,4 @@ jobs:
           shell_file_to_run: 'scripts/execute_integration_tests.sh'
           fixtures_file: 'fixtures/initial_data.json'
           openedx_imports_test_file_path: 'eox_core/edxapp_wrapper/tests/integration/test_backends.py'
-          openedx_imports_test_function_name: 'test_current_settings_code_imports'
+

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,4 +18,3 @@ jobs:
           shell_file_to_run: 'scripts/execute_integration_tests.sh'
           fixtures_file: 'fixtures/initial_data.json'
           openedx_imports_test_file_path: 'eox_core/edxapp_wrapper/tests/integration/test_backends.py'
-

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ jobs:
         tutor_version: ['<18.0.0', '<19.0.0', 'nightly']
     steps:
       - name: Run Integration Tests
-        uses: eduNEXT/integration-test-in-tutor@mjh/run-integration-tests-outside-container
+        uses: eduNEXT/integration-test-in-tutor@main
         with:
           tutor_version: ${{ matrix.tutor_version }}
           app_name: 'eox-core'


### PR DESCRIPTION
## Description

This PR includes the following updates:

1. **Updated Action Branch**: Changed the branch of the action that executes the integration tests to use the main branch with the latest changes. This update allows the tests to run outside the LMS container:
   - `uses: eduNEXT/integration-test-in-tutor@main`

2. **Removed Unnecessary Input**: Removed the `openedx_imports_test_function_name` input, as it is no longer required with the latest changes:
   - `openedx_imports_test_function_name: 'test_current_settings_code_imports'`

These changes ensure the workflow is aligned with the latest improvements and simplifies the testing process.

## Testing instructions

- Check the integration tests in the PR checks are executed successfully for tutor versions: 17.0.0, 18.0.0, and nightly
