### PR TITLE
ci: add dependabot config for enable github action auto update`AP-1514`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description

This PR adds the `dependabot.yml` file to perform automated upgrading to GitHub actions. The current configuration creates a Weekly PR (on Mondays) with the changes.

### Jira Issue
[AP-1514](https://edunext.atlassian.net/browse/AP-1514)

[AP-1514]: https://edunext.atlassian.net/browse/AP-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ