### PR TITLE
ci: use major versions in workflow actions `AP-1514`

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1.7.0
+      - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_max_size: '10'


### PR DESCRIPTION
### Description

This PR updates the versions of the workflow actions to use the MAJOR version (if possible).

### Jira Issue
[AP-1514](https://edunext.atlassian.net/browse/AP-1514)

[AP-1514]: https://edunext.atlassian.net/browse/AP-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ