### PR TITLE
chore: removed unnecessary constraints

### DIFF
--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -216,6 +216,10 @@ class WrittableEdxappUserSerializer(EdxappExtendedUserSerializer):
         has_profile = hasattr(instance, 'profile')
 
         extra_registration_fields.update(extended_profile_fields)
+
+        # Initialize profile_meta to avoid potential unassigned variable warning
+        profile_meta = {}
+        
         if has_profile:
             profile_meta = instance.profile.get_meta()
 

--- a/eox_core/api/v1/serializers.py
+++ b/eox_core/api/v1/serializers.py
@@ -44,6 +44,7 @@ class EdxappWithWarningSerializer(serializers.Serializer):
     """
     Mixin serializer to add a warning field to Edxapp serializers
     """
+
     def __init__(self, *args, **kwargs):
         """
         Conditionally adds a warning field if a context is passed
@@ -219,7 +220,7 @@ class WrittableEdxappUserSerializer(EdxappExtendedUserSerializer):
 
         # Initialize profile_meta to avoid potential unassigned variable warning
         profile_meta = {}
-        
+
         if has_profile:
             profile_meta = instance.profile.get_meta()
 
@@ -295,6 +296,7 @@ class EdxappValidatedCourseIDField(serializers.Field):
     """
     CourseKey Field
     """
+
     def to_representation(self, value):
         return str(value)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -136,7 +136,7 @@ edx-django-utils==7.0.0
     #   edx-when
     #   event-tracking
     #   openedx-events
-edx-drf-extensions==10.4.0
+edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.in
     #   edx-proctoring
@@ -149,7 +149,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-proctoring
     #   edx-when
     #   openedx-events
-edx-proctoring==4.18.2
+edx-proctoring==4.18.3
     # via -r requirements/base.in
 edx-rest-api-client==6.0.0
     # via edx-proctoring
@@ -302,7 +302,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 web-fragments==2.2.0
     # via xblock
-webob==1.8.8
+webob==1.8.9
     # via xblock
 xblock==5.1.0
     # via edx-when

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,7 +15,6 @@
 # Ensures a consistent pylint version across all Python environments to avoid triggering varying warnings
 pylint<3.3.0
 
-# Date: 2023-07-31
 # As it is not clarified what exact breaking changes will be introduced as per
 # the next major release, ensure the installed version is within boundaries.
 # Issue for unpinning: https://github.com/openedx/edx-platform/issues/32884

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,7 +15,7 @@
 # Ensures a consistent pylint version across all Python environments to avoid triggering varying warnings
 pylint<3.3.0
 
-# Higher version has breaking changes in the platform
+# Higher version has breaking changes in the platform as described here https://github.com/openedx/edx-platform/issues/35277
 django-oauth-toolkit<2.0.0
 
 # backports.zoneinfo is only needed for Python < 3.9

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,11 @@
 # Common constraints for Open edX repos
 -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# Keep same platform version
-pylint<3.0
-pycodestyle<2.9.0
+# Versions >= 3.3.0 drop support for Python 3.8
+# Ensures a consistent pylint version across all Python environments to avoid triggering varying warnings
+pylint<3.3.0
+
+# Higher version has breaking changes in the platform
 django-oauth-toolkit<2.0.0
 
 # backports.zoneinfo is only needed for Python < 3.9

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,7 +15,10 @@
 # Ensures a consistent pylint version across all Python environments to avoid triggering varying warnings
 pylint<3.3.0
 
-# Higher version has breaking changes in the platform as described here https://github.com/openedx/edx-platform/issues/35277
+# Date: 2023-07-31
+# As it is not clarified what exact breaking changes will be introduced as per
+# the next major release, ensure the installed version is within boundaries.
+# Issue for unpinning: https://github.com/openedx/edx-platform/issues/32884
 django-oauth-toolkit<2.0.0
 
 # backports.zoneinfo is only needed for Python < 3.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,7 +17,7 @@ asgiref==3.8.1
     #   -r requirements/base.txt
     #   django
     #   django-countries
-astroid==2.15.8
+astroid==3.2.4
     # via pylint
 attrs==24.2.0
     # via
@@ -186,7 +186,7 @@ edx-django-utils==7.0.0
     #   edx-when
     #   event-tracking
     #   openedx-events
-edx-drf-extensions==10.4.0
+edx-drf-extensions==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-proctoring
@@ -199,7 +199,7 @@ edx-opaque-keys[django]==2.11.0
     #   edx-proctoring
     #   edx-when
     #   openedx-events
-edx-proctoring==4.18.2
+edx-proctoring==4.18.3
     # via -r requirements/base.txt
 edx-rest-api-client==6.0.0
     # via
@@ -222,7 +222,7 @@ exceptiongroup==1.2.2
     # via pytest
 factory-boy==3.3.1
     # via -r requirements/test.in
-faker==30.8.0
+faker==30.8.2
     # via factory-boy
 fastavro==1.9.7
     # via
@@ -260,8 +260,6 @@ kombu==5.4.2
     # via
     #   -r requirements/base.txt
     #   celery
-lazy-object-proxy==1.10.0
-    # via astroid
 lxml==5.3.0
     # via
     #   -r requirements/base.txt
@@ -315,10 +313,8 @@ psutil==6.1.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.8.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
+pycodestyle==2.12.1
+    # via -r requirements/test.in
 pycparser==2.22
     # via
     #   -r requirements/base.txt
@@ -335,7 +331,7 @@ pyjwt[crypto]==2.9.0
     #   edx-proctoring
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.7
+pylint==3.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
@@ -484,12 +480,10 @@ web-fragments==2.2.0
     # via
     #   -r requirements/base.txt
     #   xblock
-webob==1.8.8
+webob==1.8.9
     # via
     #   -r requirements/base.txt
     #   xblock
-wrapt==1.16.0
-    # via astroid
 xblock==5.1.0
     # via
     #   -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -32,9 +32,9 @@ tomli==2.0.2
     # via
     #   pyproject-api
     #   tox
-tox==4.23.1
+tox==4.23.2
     # via -r requirements/tox.in
 typing-extensions==4.12.2
     # via tox
-virtualenv==20.27.0
+virtualenv==20.27.1
     # via tox


### PR DESCRIPTION
**Description**

This PR removes the pycodestyle as the issue was already fixed [here](https://github.com/PyCQA/pycodestyle/issues/1090) and added a comment explaing why the django-oauth-toolkit<2.0.0 is necessary.
 