### PR TITLE
ci: set fail-fast as False to allow integration tests to continue on nightly Tutor failures

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,3 +21,5 @@ jobs:
           fixtures_file: 'fixtures/initial_data.json'
           openedx_imports_test_file_path: 'eox_core/edxapp_wrapper/tests/integration/test_backends.py'
           tutor_extra_commands_path: 'integration_tests/scripts/execute_tutor_extra_commands.sh'
+        continue-on-error: ${{ matrix.tutor_version == 'nightly' }}
+

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,5 +21,3 @@ jobs:
           fixtures_file: 'fixtures/initial_data.json'
           openedx_imports_test_file_path: 'eox_core/edxapp_wrapper/tests/integration/test_backends.py'
           tutor_extra_commands_path: 'integration_tests/scripts/execute_tutor_extra_commands.sh'
-        continue-on-error: ${{ matrix.tutor_version == 'nightly' }}
-

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tutor_version: ['<19.0.0', '<20.0.0', 'nightly']
+        tutor_version: ['<18.0.0', '<19.0.0']
+        include:
+          - tutor_version: 'nightly'
+            continue_on_error: true
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,11 +6,9 @@ jobs:
     name: Tutor Integration Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        tutor_version: ['<18.0.0', '<19.0.0']
-        include:
-          - tutor_version: 'nightly'
-            continue_on_error: true
+        tutor_version: ['<19.0.0', '<20.0.0', 'nightly']
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main


### PR DESCRIPTION
## Description

This PR updates the Tutor Integration Tests workflow to ensure that failures in the nightly version of Tutor do not cancel the execution of tests for stable versions (<18.0.0 and <19.0.0).  `fail-fast: false` is added to the strategy, allowing the workflow to proceed even if nightly fails.

This change is important because the nightly version of Tutor is not stable and may occasionally fail due to issues unrelated to our tests. By implementing this update, we ensure that failures in nightly do not block critical tests for stable versions.