### PR TITLE
ci(integration-tests-workflow): rename nightly to main in tutor_version matrix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<19.0.0', '<20.0.0', 'nightly']
+        tutor_version: ['<19.0.0', '<20.0.0', 'main']
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main


### PR DESCRIPTION
### Summary  
Renamed the `nightly` version in the Tutor Integration Tests Workflow to `main`. This aligns with the recent Tutor branch renaming discussed [here](https://discuss.openedx.org/t/tutor-branches-rename/14455).

### Details  
- Tutor has officially renamed the `nightly` branch to `main`.  
- Updated the `nightly` tutor_version in the workflow to ensure compatibility with the new branch structure.
