### PR TITLE
feat: add JWT signed authentication for OAuth application API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
 
+## [v11.3.0](https://github.com/eduNEXT/eox-core/compare/v11.2.0...v11.3.0) - (2025-03-02)
+
+### Added
+- Added signed JWT authentication for the OAuth application API to support secure authentication when creating tenant OAuth clients from Control Center.
+
 ## [v11.2.0](https://github.com/eduNEXT/eox-core/compare/v11.1.0...v11.2.0) - (2025-01-20)
 
 ### Added

--- a/eox_core/__init__.py
+++ b/eox_core/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for main eox-core app
 """
-__version__ = '11.2.0'
+__version__ = '11.3.0'

--- a/eox_core/api/support/v1/authentication.py
+++ b/eox_core/api/support/v1/authentication.py
@@ -1,0 +1,56 @@
+"""
+Custom authenticators for the Support V1 API.
+"""
+import time
+
+import jwt
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+from jwt import ExpiredSignatureError, InvalidTokenError
+from rest_framework import authentication
+from rest_framework.authentication import get_authorization_header
+
+
+class JWTsignedOauthAppAuthentication(authentication.BaseAuthentication):
+    """
+    Authentication class to verify JWTs signed by trusted services.
+    Allows authentication for the OauthApplicationAPIView in Open edX.
+    """
+
+    def authenticate(self, request):
+        """
+        Extracts the JWT token from the Authorization header and verifies it.
+        If authentication fails, it does NOT raise an exception to allow
+        other authentication classes to attempt authentication.
+        """
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != b'bearer':
+            return None
+
+        if len(auth) != 2:
+            return None
+
+        token = auth[1]
+        return self.authenticate_token(token)
+
+    def authenticate_token(self, token):
+        """
+        Attempts to authenticate the JWT token. If verification fails,
+        returns None instead of raising an exception, allowing other authentication
+        classes to handle authentication.
+        """
+        try:
+            decoded_payload = jwt.decode(
+                token,
+                settings.EOX_CORE_JWT_SIGNED_OAUTH_APP_PUBLIC_KEY,
+                algorithms=["RS256"]
+            )
+
+            if decoded_payload["exp"] < time.time():
+                return None
+
+            return (AnonymousUser(), None)
+
+        except (ExpiredSignatureError, InvalidTokenError):
+            return None

--- a/eox_core/api/support/v1/permissions.py
+++ b/eox_core/api/support/v1/permissions.py
@@ -3,6 +3,7 @@
 """
 Custom Support API permissions module
 """
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import exceptions, permissions
 
 
@@ -17,7 +18,7 @@ class EoxCoreSupportAPIPermission(permissions.BasePermission):
         For now, to grant access only checks if the requesting user:
             1) is_staff
         """
-        if request.user.is_staff:
+        if request.user is None or isinstance(request.user, AnonymousUser) or request.user.is_staff:
             return True
 
         # To prevent leaking important information we return the most basic message.

--- a/eox_core/api/support/v1/permissions.py
+++ b/eox_core/api/support/v1/permissions.py
@@ -6,6 +6,8 @@ Custom Support API permissions module
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import exceptions, permissions
 
+from eox_core.api.support.v1.authentication import JWTsignedOauthAppAuthentication
+
 
 class EoxCoreSupportAPIPermission(permissions.BasePermission):
     """
@@ -15,10 +17,16 @@ class EoxCoreSupportAPIPermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
         """
-        For now, to grant access only checks if the requesting user:
-            1) is_staff
+        Grants access if:
+        1) The user was authenticated via the signed JWT token (AnonymousUser but authenticated).
+        2) The user is authenticated and is a staff user.
         """
-        if request.user is None or isinstance(request.user, AnonymousUser) or request.user.is_staff:
+        if isinstance(request.user, AnonymousUser):
+            auth_class_used = getattr(request.successful_authenticator, "__class__", None)
+            if auth_class_used == JWTsignedOauthAppAuthentication:
+                return True
+
+        if request.user.is_staff:
             return True
 
         # To prevent leaking important information we return the most basic message.

--- a/eox_core/api/support/v1/views.py
+++ b/eox_core/api/support/v1/views.py
@@ -20,6 +20,7 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from eox_core.api.support.v1.authentication import JWTsignedOauthAppAuthentication
 from eox_core.api.support.v1.permissions import EoxCoreSupportAPIPermission
 from eox_core.api.support.v1.serializers import (
     OauthApplicationSerializer,
@@ -154,7 +155,7 @@ class OauthApplicationAPIView(UserQueryMixin, APIView):
     django_oauth_toolkit Application object.
     """
 
-    authentication_classes = (BearerAuthentication, SessionAuthentication, JwtAuthentication)
+    authentication_classes = (JWTsignedOauthAppAuthentication, BearerAuthentication, SessionAuthentication, JwtAuthentication)
     permission_classes = (EoxCoreSupportAPIPermission,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -50,6 +50,7 @@ def plugin_settings(settings):
     settings.EOX_CORE_ASYNC_TASKS = []
     settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND = 'eox_core.edxapp_wrapper.backends.third_party_auth_l_v1'
     settings.EOX_CORE_LANG_PREF_BACKEND = 'eox_core.edxapp_wrapper.backends.lang_pref_middleware_p_v1'
+    settings.EOX_CORE_JWT_SIGNED_OAUTH_APP_PUBLIC_KEY = ''
 
     if settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
         settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.2.0
+current_version = 11.3.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import re
 
 from setuptools import setup
 
-
 with open("README.rst", "r") as fh:
     README = fh.read()
 


### PR DESCRIPTION
#### Summary
This PR adds a **custom authentication class** (`JWTsignedOauthAppAuthentication`) that allows authentication using a **signed JWT token** for the `OauthApplicationAPIView`.  

Your explanation is clear but a bit **wordy** and could be structured more logically for better readability. Here's a **more concise and natural version**:

#### **Motivation for this addition**  
When a new subscription is registered from Control Center, we need to call this `eox-core` endpoint to create the **tenant OAuth client** for the instance. However, at this stage, Control Center does **not yet have** the OAuth client credentials needed to generate a JWT token for authentication.  

This authentication mechanism allows the request to be securely made using a **signed JWT token**, eliminating the need for pre-existing credentials.  

Once the **tenant OAuth client** is created, its credentials are stored in Control Center, enabling future **authenticated API requests** to the Open edX instance.  

#### **Key Changes**  
- Implements `JWTsignedOauthAppAuthentication`, which:
  - Extracts the JWT token from the `Authorization` header.
  - Verifies the token signature **without raising exceptions** if authentication fails, allowing fallback to other authentication methods.
  - Returns AnonymousUser() upon successful authentication.
- Enables secure authentication for service-to-service communication between Control Center and the Open edX instances.  


### **How to Test**
1. **Generate RSA Key Pair (Private & Public Keys)**
   - Run the following commands to generate the keys:
     ```sh
     openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
     openssl rsa -in private_key.pem -pubout -out public_key.pem
     ```
   - Use the **public key** in Open edX (`settings.EOX_CORE_JWT_SIGNED_OAUTH_APP_PUBLIC_KEY`).
   - Keep the **private key** in a secure location for signing JWTs.

2. **Generate a Signed JWT**
   - Use the **private key** to generate a JWT token:
     ```python
     import jwt
     import time
     import uuid

     private_key_path = "private_key.pem"

     with open(private_key_path, "r") as f:
         private_key = f.read()

     payload = {
         "iat": int(time.time()),
         "exp": int(time.time()) + 300,  # Token expires in 5 minutes
         "nonce": str(uuid.uuid4()),  # Prevents replay attacks
     }

     token = jwt.encode(payload, private_key, algorithm="RS256")
     print(f"Generated JWT Token: {token}")
     ```
   
3. **Make a Request to the API**
   - Use the generated JWT in the `Authorization` header:
     ```sh
     curl -X POST "<domain>/eox-core/support-api/v1/oauth-application/" \
          -H "Authorization: Bearer YOUR_GENERATED_JWT" \
          -H "Content-Type: application/json" \
          -d '{
                    {
                        "user": {
                            "fullname": "John Doe",
                            "email": "johndoe@example.com",
                            "username": "johndoe",
                            "permissions": ["can_call_eox_core", "can_call_eox_tenant"]
                        },
                        "redirect_uris": "http://testing-site.io/ http://testing-site.io",
                        "client_type":"confidential",
                        "authorization_grant_type":"client-credentials",
                        "name": "test-application",
                        "skip_authorization": true
                    }
          }'
     ```
   - Ensure the request **returns a successful response**.