### PR TITLE
feat: add teak and remove redwood tutor versions from integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<19.0.0', '<20.0.0', 'main']
+        tutor_version: ['<20.0.0', '<21.0.0', 'main']
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
 
+## [v12.1.0](https://github.com/eduNEXT/eox-core/compare/v12.0.0...v12.1.0) - (2025-07-01)
+
+### Added
+
+- Integration tests now run against Tutor Teak (`<21.0.0`) instead of Redwood (`<19.0.0`), keeping CI aligned with currently supported Open edX releases.
+
 ## [v12.0.0](https://github.com/eduNEXT/eox-core/compare/v11.3.0...v12.0.0) - (2025-06-09)
 
 #### ⚠ BREAKING CHANGES

--- a/eox_core/__init__.py
+++ b/eox_core/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for main eox-core app
 """
-__version__ = '12.0.0'
+__version__ = '12.1.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 12.0.0
+current_version = 12.1.0
 commit = False
 tag = False
 


### PR DESCRIPTION
This PR updates the Tutor versions used in integration tests to include Tutor Teak and remove Redwood support.