### PR TITLE
feat: add flag to allow permanent user deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please do not update the unreleased notes.
 ### Added
 
 - New API endpoint to support user email changes.
+- Support for permanent user deletion via Users API when the feature is enabled.
 
 ## [v12.2.1](https://github.com/eduNEXT/eox-core/compare/v12.2.0...v12.2.1) - (2025-12-18)
 

--- a/eox_core/edxapp_wrapper/backends/users_q_v1.py
+++ b/eox_core/edxapp_wrapper/backends/users_q_v1.py
@@ -265,9 +265,41 @@ def get_edxapp_user(**kwargs):
     return user
 
 
-def delete_edxapp_user(*args, **kwargs):
+def permanently_delete_user(*args, **kwargs):
+    """Hard deletes a user from the platform.
+
+    This function permanently removes the user from the database. It is
+    irreversible and should be used with caution. All associated objects should
+    be handled via cascading deletes or other mechanisms as needed. The
+    only object manually deleted here are the OAuth tokens associated with the user.
     """
-    Deletes a user from the platform.
+    user = kwargs.get("user")
+
+    with transaction.atomic():
+        # Delete OAuth tokens associated with the user before deleting the user.
+        # These are not set to cascade delete automatically.
+        retire_dot_oauth2_models(user)
+        UserSocialAuth.objects.filter(user_id=user.id).delete()
+
+        user.delete()
+
+    return (
+        f"The user {user.username} <{user.email}> has been permanently deleted",
+        status.HTTP_200_OK,
+    )
+
+
+def retire_user_with_cascade_delete(*args, **kwargs):
+    """Deletes a user from the platform by retiring them.
+
+    This function renames the user's email and username to indicate that
+    the account has been retired, adds the user to the retirement queue, unlinks
+    social auth accounts, sets an unusable password, removes activation keys,
+    deletes OAuth tokens, and deletes the user's signup source for the specified
+    site.
+
+    If the user tries to register again with the same email or username, the
+    system will recognize that the account has been retired.
     """
     msg = None
 
@@ -319,6 +351,19 @@ def delete_edxapp_user(*args, **kwargs):
         return msg, status.HTTP_200_OK
 
     raise NotFound(f"{user_response} does not have a signup source on the site {site}")
+
+
+def delete_edxapp_user(*args, **kwargs):
+    """Deletes a user from the platform by either retiring or permanently deleting them.
+
+    The method used depends on the EOX_CORE_ALLOW_PERMANENT_USER_DELETION setting.
+
+    If EOX_CORE_ALLOW_PERMANENT_USER_DELETION is set to True, the user will be
+    permanently deleted from the database. This action is irreversible.
+    """
+    if getattr(settings, "EOX_CORE_ALLOW_PERMANENT_USER_DELETION", False):
+        return permanently_delete_user(*args, **kwargs)
+    return retire_user_with_cascade_delete(*args, **kwargs)
 
 
 def get_course_team_user(*args, **kwargs):

--- a/eox_core/settings/common.py
+++ b/eox_core/settings/common.py
@@ -51,6 +51,7 @@ def plugin_settings(settings):
     settings.EOX_CORE_THIRD_PARTY_AUTH_BACKEND = 'eox_core.edxapp_wrapper.backends.third_party_auth_l_v1'
     settings.EOX_CORE_LANG_PREF_BACKEND = 'eox_core.edxapp_wrapper.backends.lang_pref_middleware_p_v1'
     settings.EOX_CORE_JWT_SIGNED_OAUTH_APP_PUBLIC_KEY = ''
+    settings.EOX_CORE_ALLOW_PERMANENT_USER_DELETION = False
 
     if settings.EOX_CORE_USER_ENABLE_MULTI_TENANCY:
         settings.EOX_CORE_USER_ORIGIN_SITE_SOURCES = [


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

Use a feature flag to allow permanent deletion of a user and their related objects. This path would skip the retirement pipeline, where some PII is anonymized but still prevents a user from registering again with the same email or username. The feature flag would be off by default, so the current deletion behavior is maintained unless an administrator explicitly enables permanent deletion.

I also considered adding a separate delete endpoint to avoid surprising API users once the flag is enabled. A user could call delete user expecting the usual behavior and instead fully remove the account without realizing that permanent deletion is active. The downside is that we would end up with two delete endpoints that look very similar, which could be confusing.

What do you think about this approach?

## Testing instructions

1. Inlcude this configuration in a tutor plugin to enable permanent deletions:

```
from tutor import hooks

hooks.Filters.ENV_PATCHES.add_item(
    (
        "openedx-lms-common-settings",
"""
EOX_CORE_ALLOW_PERMANENT_USER_DELETION = True
"""
    )
)
```
3. Create a user using the API or another mechanism, and then call the delete endpoint as usual:
<img width="1091" height="637" alt="Screenshot from 2026-01-02 12-42-20" src="https://github.com/user-attachments/assets/5aed42de-e236-412a-b9ab-f4364991371d" />

## Additional information
A client was about to use this API. While reviewing it, we noticed a problem. As with the LMS deletion flow, once a user account is deleted, the same username or email cannot be used again.

This goes against the client’s internal policies. It can also raise GDPR concerns, because the system still appears to keep the user’s PII, even if it is anonymized. This is the main reason for allowing administrators to fully delete users.

## Checklist for Merge

- [x] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->