### PR TITLE
chore: update integration test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,10 +9,10 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        tutor_version: ['<21.0.0', 'main']
+        tutor_version: ['<21.0.0', '<22.0.0', 'main']
     steps:
       - name: Run Integration Tests
-        uses: eduNEXT/integration-test-in-tutor@v0.1.0
+        uses: eduNEXT/integration-test-in-tutor@v0.1.3
         with:
           tutor_version: ${{ matrix.tutor_version }}
           tutor_plugins: 'forum'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
 
+## [v12.3.1](https://github.com/eduNEXT/eox-core/compare/v12.3.0...v12.3.1) - (2026-01-20)
+
+### Changed
+
+- Update Tutor integration-tests GitHub Action version to avoid integration test failures.
+
 ## [v12.3.0](https://github.com/eduNEXT/eox-core/compare/v12.2.1...v12.3.0) - (2026-01-12)
 
 ### Added

--- a/eox_core/__init__.py
+++ b/eox_core/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for main eox-core app
 """
-__version__ = '12.3.0'
+__version__ = '12.3.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 12.2.1
+current_version = 12.3.1
 commit = False
 tag = False
 


### PR DESCRIPTION
This pull request updates the project version to `12.3.1` and addresses integration test reliability by updating the Tutor integration-tests GitHub Action. The main focus is on ensuring compatibility with newer Tutor versions and preventing test failures.

Version updates:

* Updated the project version to `12.3.1` in `eox_core/__init__.py` and `setup.cfg`. [[1]](diffhunk://#diff-7a68b57a2c1a15d8250711c59867039ed45a8084eb8311a27d50efb8970c116aL4-R4) [[2]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L2-R2)
* Added release notes for version `v12.3.1` in `CHANGELOG.md`.

Integration test improvements:

* Updated the Tutor integration-tests GitHub Action to version `v0.1.2` and expanded the test matrix to include Tutor versions `<22.0.0`, improving test coverage and reliability in `.github/workflows/integration-test.yml`.